### PR TITLE
update apirules to version 2

### DIFF
--- a/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-apirule.yaml
+++ b/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-apirule.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.apirule.enabled .Values.enabled }}
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   labels:

--- a/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apirule.enabled .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "aas-discovery.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-deployment.yaml
+++ b/charts/basyx/dependency_charts/aas-discovery/templates/aas-discovery-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "aas-discovery.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-apirule.yaml
+++ b/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-apirule.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.apirule.enabled .Values.enabled }}
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   labels:

--- a/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apirule.enabled .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "aas-environment.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-deployment.yaml
+++ b/charts/basyx/dependency_charts/aas-environment/templates/aas-environment-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "aas-environment.selectorLabels" . | nindent 8 }}
     spec:
       volumes:

--- a/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-apirule.yaml
+++ b/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-apirule.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.apirule.enabled .Values.enabled }}
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   labels:
-    {{- include "aas-environment.labels" . | nindent 4 }}
-  name: {{ include "aas-environment.fullname" . }}
+    {{- include "aas-registry.labels" . | nindent 4 }}
+  name: {{ include "aas-registry.fullname" . }}
 spec:
   gateway: kyma-system/kyma-gateway
   {{- if .Values.apirule.corsPolicy }}

--- a/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apirule.enabled .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "aas-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-deployment.yaml
+++ b/charts/basyx/dependency_charts/aas-registry/templates/aas-registry-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "aas-registry.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-apirule.yaml
+++ b/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-apirule.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.apirule.enabled .Values.enabled }}
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   labels:

--- a/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apirule.enabled .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "aas-web-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-deployment.yaml
+++ b/charts/basyx/dependency_charts/aas-web-ui/templates/aas-web-ui-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "aas-web-ui.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/basyx/dependency_charts/mqtt/templates/apirule.yaml
+++ b/charts/basyx/dependency_charts/mqtt/templates/apirule.yaml
@@ -25,7 +25,7 @@
 {{- if .enabled }}
 {{- $annotations := .annotations | default dict }}
 ---
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   name: {{ $fullName }}-{{ .type }}

--- a/charts/basyx/dependency_charts/mqtt/templates/authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/mqtt/templates/authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "sm-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/mqtt/templates/deployment.yaml
+++ b/charts/basyx/dependency_charts/mqtt/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "mqtt.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-apirule.yaml
+++ b/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-apirule.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.apirule.enabled .Values.enabled }}
-apiVersion: gateway.kyma-project.io/v2alpha1
+apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
   labels:

--- a/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-authorization-policy.yaml
+++ b/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-authorization-policy.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apirule.enabled .Values.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "sm-registry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            notPrincipals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+{{ end -}}

--- a/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-deployment.yaml
+++ b/charts/basyx/dependency_charts/sm-registry/templates/sm-registry-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.apirule.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{ end -}}
         {{- include "sm-registry.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
This PR updates the Kyma APIRules to [version 2](https://kyma-project.io/#/api-gateway/user/custom-resources/apirule/04-70-changes-in-apirule-v2?id=a-workload-must-be-in-the-istio-service-mesh).

