### PR TITLE
fix: add bitnamilegacy image to mongodb values

### DIFF
--- a/charts/basyx/values.mongodb.yaml
+++ b/charts/basyx/values.mongodb.yaml
@@ -26,6 +26,9 @@
 ---
 # MongoDB - used by new Basyx - both Registry, Environment and other aspects.
 architecture: standalone
+image:
+  repository: bitnamilegacy/mongodb
+  tag: 8.0.13-debian-12-r0
 auth:
   rootUser: adminUser
   rootPassword: adminPassword


### PR DESCRIPTION
This PR adds the bitnamilegacy/mongodb image to the MongoDB values.

close #37 