### PR TITLE
fix: removing quotes from CORS properties

### DIFF
--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -28,7 +28,7 @@ apiVersion: v2
 name: aas-basyx-v2-full
 description: Umbrella chart for the AAS Basyx v2 Environment
 type: application
-version: 2.1.12
+version: 2.1.13
 appVersion: 2.0.0-milestone-06
 
 dependencies:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -450,8 +450,8 @@ aas-registry:
 
     logging.level.root=DEBUG
 
-    basyx.cors.allowed-origins="*"
-    basyx.cors.allowed-methods="GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD"
+    basyx.cors.allowed-origins=*
+    basyx.cors.allowed-methods=GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD
 
     # Depends on: @param keycloak.enabled
     basyx.feature.authorization.enabled = false
@@ -652,8 +652,8 @@ sm-registry:
 
     logging.level.root=DEBUG
 
-    basyx.cors.allowed-origins="*"
-    basyx.cors.allowed-methods="GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD"
+    basyx.cors.allowed-origins=*
+    basyx.cors.allowed-methods=GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD
 
     # Depends on: @param keycloak.enabled
     basyx.feature.authorization.enabled = false


### PR DESCRIPTION
## Summary

This PR removes all quotes from CORS configuration, keeping all components configurations consistent.

## Testing

With the current values, some components, such as **aas-environment**, have the CORS properties with quotes:

```sh
nobody@basyx-aas-environment-68695cc48b-dht9w:/application$ cat application.properties

(...)
basyx.cors.allowed-origins="*"
basyx.cors.allowed-methods="GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD"
```

And as we can see, it won't allow all origins, as intended:

```sh
nobody@basyx-aas-environment-68695cc48b-dht9w:/application$ curl -i -H "Origin: http://example.com" -X OPTIONS http://localhost:8081/shells
HTTP/1.1 403
AAS_Middleware: BaSyx
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Transfer-Encoding: chunked
Date: Fri, 23 Jan 2026 12:19:25 GMT

Invalid CORS request
```

After removing quotes:

```sh
nobody@basyx-aas-environment-68695cc48b-5ft46:/application$ cat application.properties

(...)
basyx.cors.allowed-origins=*
basyx.cors.allowed-methods=GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD

nobody@basyx-aas-environment-68695cc48b-5ft46:/application$ curl -i -H "Origin: http://example.com" -X OPTIONS http://localhost:8081/shells
HTTP/1.1 200
AAS_Middleware: BaSyx
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Access-Control-Allow-Origin: http://example.com
Allow: GET,HEAD,POST,OPTIONS
Accept-Patch:
Content-Length: 0
Date: Fri, 23 Jan 2026 12:25:20 GMT
```

## Impact

- CORS configuration effectively allows all origins out of the box, without needing to overwrite the whole config

## Further Notes

- After merging, consider applying the same changes in the dependent repositories