### PR TITLE
Add BaSyx-Go history configuration and prepare chart 3.0.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,178 @@ Supported service blocks:
 
 Most service blocks support `enabled`, `replicaCount`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `abac` overrides.
 
+### BaSyx Runtime Configuration
+
+BaSyx Go runtime options can be configured globally and overridden per backend service. Global values are rendered into the shared `basyx-common-config` Secret and are loaded by all backend services. Service-local values are rendered as explicit container environment variables and therefore override the global defaults.
+
+This applies to:
+
+- `aasDiscovery`
+- `aasRegistry`
+- `aasRepository`
+- `submodelRegistry`
+- `submodelRepository`
+- `cdRepository`
+- `companyLookup`
+- `digitalTwinRegistry`
+
+Global runtime defaults:
+
+```yaml
+general:
+  trustProxyHeaders: false
+  trustedProxyCIDRs: []
+  aasPreconfigPaths: []
+
+history:
+  mode: "off"
+  immutability: "none"
+  auditIdentityMode: "none"
+  evidence:
+    enabled: false
+    provider: "none"
+
+eventing:
+  enabled: false
+  topicPrefix: basyx
+
+abac:
+  policyFileImport: ""
+  managementApi:
+    enabled: false
+```
+
+Service-local override example:
+
+```yaml
+history:
+  mode: "off"
+
+aasRepository:
+  history:
+    mode: audit
+    immutability: postgres_guarded
+    auditIdentityMode: extended
+    evidence:
+      enabled: true
+      provider: s3
+      bucket: basyx-history-evidence
+      endpoint: http://minio:9000
+      pathStyle: true
+  eventing:
+    topicPrefix: aas-repository-events
+  general:
+    aasPreconfigPaths:
+      - /aas/preconfigured
+  abac:
+    policyFileImport: if_missing
+    managementApi:
+      enabled: true
+```
+
+History settings can be overridden independently for each backend service. Use the
+global `history` block as the default for all services, then add a service-local
+`history` block where a component needs different history or audit behavior:
+
+```yaml
+history:
+  mode: "off"
+
+aasRepository:
+  history:
+    mode: api
+    fullSnapshotInterval: 1
+
+submodelRepository:
+  history:
+    mode: audit
+    immutability: postgres_guarded
+    auditIdentityMode: extended
+```
+
+In this example, history stays disabled globally, the AAS Repository records API
+history, and the Submodel Repository uses audit-oriented history settings. The
+same pattern can be used for `aasDiscovery`, `aasRegistry`, `submodelRegistry`,
+`cdRepository`, `companyLookup` and `digitalTwinRegistry`.
+
+If you need a parameter that is not modeled as a structured value yet, use the raw environment maps:
+
+```yaml
+environment:
+  common:
+    BASYX_HISTORY_MODE: api
+
+aasRepository:
+  environment:
+    BASYX_HISTORY_MODE: audit
+```
+
+Raw environment maps are the escape hatch and take precedence over structured values. In the example above, `aasRepository.environment.BASYX_HISTORY_MODE` wins over `aasRepository.history.mode`.
+
+#### General Runtime Values
+
+| Value | Rendered environment variable | Description |
+| --- | --- | --- |
+| `general.enableImplicitCasts` | `GENERAL_ENABLEIMPLICITCASTS` | Enables implicit value casts. |
+| `general.enableDescriptorDebug` | `GENERAL_ENABLEDESCRIPTORDEBUG` | Enables descriptor debug behavior. |
+| `general.discoveryIntegration` | `GENERAL_DISCOVERYINTEGRATION` | Enables AAS Discovery integration where supported. |
+| `general.enableCustomMiddlewareHeaderInjection` | `GENERAL_ENABLECUSTOMMIDDLEWAREHEADERINJECTION` | Enables custom middleware header injection. |
+| `general.supportsSingularSupplementalSemanticId` | `GENERAL_SUPPORTSSINGULARSUPPLEMENTALSEMANTICID` | Enables compatibility for singular supplemental semantic IDs. |
+| `general.aasRegistryIntegration` | `GENERAL_AASREGISTRYINTEGRATION` | Enables AAS Registry synchronization. |
+| `general.submodelRegistryIntegration` | `GENERAL_SUBMODELREGISTRYINTEGRATION` | Enables Submodel Registry synchronization. |
+| `general.externalUrl` | `GENERAL_EXTERNALURL` | Public external URL used by registry synchronization. |
+| `general.trustProxyHeaders` | `GENERAL_TRUSTPROXYHEADERS` | Trusts forwarded proxy headers. Only enable behind trusted reverse proxies. |
+| `general.trustedProxyCIDRs` | `GENERAL_TRUSTEDPROXYCIDRS` | Comma-separated trusted proxy CIDR list. |
+| `general.uploadMaxSizeBytes` | `GENERAL_UPLOADMAXSIZEBYTES` | Maximum upload size in bytes. `0` keeps the service default. |
+| `general.aasPreconfigPaths` | `GENERAL_AAS_PRECONFIG_PATHS` | Comma-separated paths for preconfigured AAS input. Mount matching files or directories with service-specific `volumes` and `volumeMounts`. |
+
+`aasRepository` and `submodelRepository` already set registry integration related values in their service-local `environment` maps by default. Override these service-local values only when you intentionally want different registry synchronization behavior.
+
+#### History, Audit And Evidence Values
+
+| Value | Rendered environment variable | Description |
+| --- | --- | --- |
+| `history.mode` | `BASYX_HISTORY_MODE` | History mode. Typical values are `off`, `api` or `audit`. |
+| `history.retentionDays` | `BASYX_HISTORY_RETENTION_DAYS` | Retention period in days. `0` keeps the service default. |
+| `history.fullSnapshotInterval` | `BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL` | Interval for full history snapshots. |
+| `history.immutability` | `BASYX_HISTORY_IMMUTABILITY` | Immutability mode, e.g. `none`, `postgres_guarded` or `external_anchor`. |
+| `history.auditIdentityMode` | `BASYX_AUDIT_IDENTITY_MODE` | Audit identity mode, e.g. `none`, `minimal` or `extended`. |
+| `history.evidence.enabled` | `BASYX_HISTORY_EVIDENCE_ENABLED` | Enables external evidence writing. |
+| `history.evidence.provider` | `BASYX_HISTORY_EVIDENCE_PROVIDER` | Evidence provider, e.g. `none` or `s3`. |
+| `history.evidence.bucket` | `BASYX_HISTORY_EVIDENCE_BUCKET` | Evidence storage bucket. |
+| `history.evidence.prefix` | `BASYX_HISTORY_EVIDENCE_PREFIX` | Object prefix for evidence storage. |
+| `history.evidence.region` | `BASYX_HISTORY_EVIDENCE_REGION` | S3-compatible region. |
+| `history.evidence.endpoint` | `BASYX_HISTORY_EVIDENCE_ENDPOINT` | S3-compatible endpoint URL. |
+| `history.evidence.accessKeyId` | `BASYX_HISTORY_EVIDENCE_ACCESS_KEY_ID` | Evidence storage access key ID. Prefer external secret handling for real credentials. |
+| `history.evidence.secretAccessKey` | `BASYX_HISTORY_EVIDENCE_SECRET_ACCESS_KEY` | Evidence storage secret access key. Prefer external secret handling for real credentials. |
+| `history.evidence.pathStyle` | `BASYX_HISTORY_EVIDENCE_PATH_STYLE` | Enables path-style S3 access. |
+| `history.evidence.retentionMode` | `BASYX_HISTORY_EVIDENCE_RETENTION_MODE` | Object lock retention mode, if supported by the backend. |
+| `history.evidence.retentionDays` | `BASYX_HISTORY_EVIDENCE_RETENTION_DAYS` | Object lock retention period in days. |
+| `history.evidence.writeTimeoutSeconds` | `BASYX_HISTORY_EVIDENCE_WRITE_TIMEOUT_SECONDS` | Evidence write timeout in seconds. |
+| `history.evidence.signing.privateKeyPath` | `BASYX_HISTORY_EVIDENCE_SIGNING_PRIVATE_KEY_PATH` | Private key path for evidence signing. Mount the key separately. |
+| `history.evidence.signing.publicKeyPath` | `BASYX_HISTORY_EVIDENCE_SIGNING_PUBLIC_KEY_PATH` | Public key path for evidence verification. Mount the key separately. |
+| `history.evidence.signing.required` | `BASYX_HISTORY_EVIDENCE_SIGNING_REQUIRED` | Requires signing for evidence records. |
+| `history.integrityAnchor.provider` | `BASYX_HISTORY_INTEGRITY_ANCHOR_PROVIDER` | Integrity anchor provider. |
+
+#### Eventing Values
+
+| Value | Rendered environment variable | Description |
+| --- | --- | --- |
+| `eventing.enabled` | `BASYX_EVENTING_ENABLED` | Enables event publishing. |
+| `eventing.format` | `BASYX_EVENTING_FORMAT` | Event payload format, default `cloudevents`. |
+| `eventing.sinks` | `BASYX_EVENTING_SINKS` | Comma-separated sink list. |
+| `eventing.outboxEnabled` | `BASYX_EVENTING_OUTBOX_ENABLED` | Enables outbox processing. |
+| `eventing.topicPrefix` | `BASYX_EVENTING_TOPIC_PREFIX` | Event topic prefix. |
+
+The current BaSyx Go implementation may fail fast when event publishing or outbox processing is enabled before a matching implementation is available. Keep `eventing.enabled: false` unless you intentionally deploy a compatible eventing setup.
+
+#### ABAC Runtime Values
+
+| Value | Rendered environment variable | Description |
+| --- | --- | --- |
+| `abac.policyFileImport` | `ABAC_POLICY_FILE_IMPORT` | Controls startup import behavior for ABAC policy files, e.g. `always`, `if_missing` or `never`. Empty value keeps the service default. |
+| `abac.managementApi.enabled` | `ABAC_MANAGEMENT_API_ENABLED` | Enables the ABAC management API where supported. |
+
 ### AAS Web UI
 
 Enable the Web UI with:

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Most service blocks support `enabled`, `replicaCount`, `image.*`, `imagePullSecr
 
 ### BaSyx Runtime Configuration
 
-BaSyx Go runtime options can be configured globally and overridden per backend service. Global values are rendered into the shared `basyx-common-config` Secret and are loaded by all backend services. Service-local values are rendered as explicit container environment variables and therefore override the global defaults.
+BaSyx Go runtime options can be configured globally and overridden per backend service. Global values are rendered into the shared `<fullname>-common-config` Secret, for example `basyx-common-config` when installing the chart as release `basyx`, and are loaded by all backend services. Service-local values are rendered as explicit container environment variables and therefore override the global defaults.
 
 This applies to:
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -6,7 +6,7 @@ description: >
   Keycloak authentication with ABAC authorization.
 type: application
 version: 3.0.0-rc.1
-appVersion: "1.0.0-rc.5"
+appVersion: "1.0.0-rc.6"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.0.0-rc.1
+version: 3.0.0-rc.2
 appVersion: "1.0.0-rc.6"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -6,7 +6,7 @@ description: >
   Keycloak authentication with ABAC authorization.
 type: application
 version: 3.0.0-rc.1
-appVersion: "46fbb7f"
+appVersion: "1.0.0-rc.5"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -94,6 +94,159 @@ Render an image reference, preferring digest over tag when provided.
 {{- end }}
 
 {{/*
+Render a common config entry unless the raw environment map explicitly overrides it.
+*/}}
+{{- define "basyx.commonConfig.entry" -}}
+{{- if not (hasKey .common .name) }}
+{{ .name }}: {{ tpl (print .value) .root | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render a comma-separated common config entry from a list.
+*/}}
+{{- define "basyx.commonConfig.listEntry" -}}
+{{- if not (hasKey .common .name) }}
+{{ .name }}: {{ join "," (default (list) .value) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render a service-local runtime env entry when the structured service config
+explicitly sets it. The raw service environment map remains the escape hatch
+and takes precedence.
+*/}}
+{{- define "basyx.serviceRuntimeEnv.entry" -}}
+{{- if and (hasKey .config .key) (not (hasKey .environment .name)) }}
+- name: {{ .name }}
+  value: {{ tpl (print (get .config .key)) .root | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render a service-local runtime env entry from a list.
+*/}}
+{{- define "basyx.serviceRuntimeEnv.listEntry" -}}
+{{- if and (hasKey .config .key) (not (hasKey .environment .name)) }}
+- name: {{ .name }}
+  value: {{ join "," (default (list) (get .config .key)) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render structured BaSyx runtime configuration as environment variables.
+The environment.common map remains the escape hatch and takes precedence.
+*/}}
+{{- define "basyx.commonConfig.runtimeEnv" -}}
+{{- $root := . -}}
+{{- $common := .Values.environment.common | default dict -}}
+{{- $general := .Values.general | default dict -}}
+{{- $history := .Values.history | default dict -}}
+{{- $evidence := dig "evidence" (dict) $history -}}
+{{- $signing := dig "signing" (dict) $evidence -}}
+{{- $integrityAnchor := dig "integrityAnchor" (dict) $history -}}
+{{- $eventing := .Values.eventing | default dict -}}
+{{- $abac := .Values.abac | default dict -}}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_ENABLEIMPLICITCASTS" "value" (dig "enableImplicitCasts" true $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_ENABLEDESCRIPTORDEBUG" "value" (dig "enableDescriptorDebug" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_DISCOVERYINTEGRATION" "value" (dig "discoveryIntegration" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_ENABLECUSTOMMIDDLEWAREHEADERINJECTION" "value" (dig "enableCustomMiddlewareHeaderInjection" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_SUPPORTSSINGULARSUPPLEMENTALSEMANTICID" "value" (dig "supportsSingularSupplementalSemanticId" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASREGISTRYINTEGRATION" "value" (dig "aasRegistryIntegration" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_SUBMODELREGISTRYINTEGRATION" "value" (dig "submodelRegistryIntegration" false $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_EXTERNALURL" "value" (dig "externalUrl" "" $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_TRUSTPROXYHEADERS" "value" (dig "trustProxyHeaders" false $general)) }}
+{{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "GENERAL_TRUSTEDPROXYCIDRS" "value" (dig "trustedProxyCIDRs" (list) $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_UPLOADMAXSIZEBYTES" "value" (dig "uploadMaxSizeBytes" 0 $general)) }}
+{{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "GENERAL_AAS_PRECONFIG_PATHS" "value" (dig "aasPreconfigPaths" (list) $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "ABAC_POLICY_FILE_IMPORT" "value" (dig "policyFileImport" "" $abac)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "ABAC_MANAGEMENT_API_ENABLED" "value" (dig "managementApi" "enabled" false $abac)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_MODE" "value" (dig "mode" "off" $history)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_RETENTION_DAYS" "value" (dig "retentionDays" 0 $history)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL" "value" (dig "fullSnapshotInterval" 1 $history)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_IMMUTABILITY" "value" (dig "immutability" "none" $history)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_AUDIT_IDENTITY_MODE" "value" (dig "auditIdentityMode" "none" $history)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_ENABLED" "value" (dig "enabled" false $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_PROVIDER" "value" (dig "provider" "none" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_BUCKET" "value" (dig "bucket" "" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_PREFIX" "value" (dig "prefix" "basyx-history-evidence" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_REGION" "value" (dig "region" "us-east-1" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_ENDPOINT" "value" (dig "endpoint" "" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_ACCESS_KEY_ID" "value" (dig "accessKeyId" "" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_SECRET_ACCESS_KEY" "value" (dig "secretAccessKey" "" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_PATH_STYLE" "value" (dig "pathStyle" false $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_RETENTION_MODE" "value" (dig "retentionMode" "" $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_RETENTION_DAYS" "value" (dig "retentionDays" 0 $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_WRITE_TIMEOUT_SECONDS" "value" (dig "writeTimeoutSeconds" 10 $evidence)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_SIGNING_PRIVATE_KEY_PATH" "value" (dig "privateKeyPath" "" $signing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_SIGNING_PUBLIC_KEY_PATH" "value" (dig "publicKeyPath" "" $signing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_EVIDENCE_SIGNING_REQUIRED" "value" (dig "required" false $signing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_HISTORY_INTEGRITY_ANCHOR_PROVIDER" "value" (dig "provider" "none" $integrityAnchor)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_EVENTING_ENABLED" "value" (dig "enabled" false $eventing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_EVENTING_FORMAT" "value" (dig "format" "cloudevents" $eventing)) }}
+{{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "BASYX_EVENTING_SINKS" "value" (dig "sinks" (list) $eventing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_EVENTING_OUTBOX_ENABLED" "value" (dig "outboxEnabled" false $eventing)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "BASYX_EVENTING_TOPIC_PREFIX" "value" (dig "topicPrefix" "basyx" $eventing)) }}
+{{- end }}
+
+{{/*
+Render service-local BaSyx runtime overrides as explicit container env values.
+*/}}
+{{- define "basyx.serviceRuntimeEnv" -}}
+{{- $root := .root -}}
+{{- $values := .values | default dict -}}
+{{- $environment := $values.environment | default dict -}}
+{{- $general := $values.general | default dict -}}
+{{- $history := $values.history | default dict -}}
+{{- $evidence := $history.evidence | default dict -}}
+{{- $signing := $evidence.signing | default dict -}}
+{{- $integrityAnchor := $history.integrityAnchor | default dict -}}
+{{- $eventing := $values.eventing | default dict -}}
+{{- $abac := $values.abac | default dict -}}
+{{- $abacManagementApi := $abac.managementApi | default dict -}}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "enableImplicitCasts" "name" "GENERAL_ENABLEIMPLICITCASTS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "enableDescriptorDebug" "name" "GENERAL_ENABLEDESCRIPTORDEBUG") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "discoveryIntegration" "name" "GENERAL_DISCOVERYINTEGRATION") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "enableCustomMiddlewareHeaderInjection" "name" "GENERAL_ENABLECUSTOMMIDDLEWAREHEADERINJECTION") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "supportsSingularSupplementalSemanticId" "name" "GENERAL_SUPPORTSSINGULARSUPPLEMENTALSEMANTICID") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasRegistryIntegration" "name" "GENERAL_AASREGISTRYINTEGRATION") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "submodelRegistryIntegration" "name" "GENERAL_SUBMODELREGISTRYINTEGRATION") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "externalUrl" "name" "GENERAL_EXTERNALURL") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "trustProxyHeaders" "name" "GENERAL_TRUSTPROXYHEADERS") }}
+{{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $general "key" "trustedProxyCIDRs" "name" "GENERAL_TRUSTEDPROXYCIDRS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "uploadMaxSizeBytes" "name" "GENERAL_UPLOADMAXSIZEBYTES") }}
+{{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $general "key" "aasPreconfigPaths" "name" "GENERAL_AAS_PRECONFIG_PATHS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $abac "key" "policyFileImport" "name" "ABAC_POLICY_FILE_IMPORT") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $abacManagementApi "key" "enabled" "name" "ABAC_MANAGEMENT_API_ENABLED") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $history "key" "mode" "name" "BASYX_HISTORY_MODE") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $history "key" "retentionDays" "name" "BASYX_HISTORY_RETENTION_DAYS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $history "key" "fullSnapshotInterval" "name" "BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $history "key" "immutability" "name" "BASYX_HISTORY_IMMUTABILITY") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $history "key" "auditIdentityMode" "name" "BASYX_AUDIT_IDENTITY_MODE") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "enabled" "name" "BASYX_HISTORY_EVIDENCE_ENABLED") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "provider" "name" "BASYX_HISTORY_EVIDENCE_PROVIDER") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "bucket" "name" "BASYX_HISTORY_EVIDENCE_BUCKET") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "prefix" "name" "BASYX_HISTORY_EVIDENCE_PREFIX") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "region" "name" "BASYX_HISTORY_EVIDENCE_REGION") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "endpoint" "name" "BASYX_HISTORY_EVIDENCE_ENDPOINT") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "accessKeyId" "name" "BASYX_HISTORY_EVIDENCE_ACCESS_KEY_ID") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "secretAccessKey" "name" "BASYX_HISTORY_EVIDENCE_SECRET_ACCESS_KEY") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "pathStyle" "name" "BASYX_HISTORY_EVIDENCE_PATH_STYLE") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "retentionMode" "name" "BASYX_HISTORY_EVIDENCE_RETENTION_MODE") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "retentionDays" "name" "BASYX_HISTORY_EVIDENCE_RETENTION_DAYS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $evidence "key" "writeTimeoutSeconds" "name" "BASYX_HISTORY_EVIDENCE_WRITE_TIMEOUT_SECONDS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $signing "key" "privateKeyPath" "name" "BASYX_HISTORY_EVIDENCE_SIGNING_PRIVATE_KEY_PATH") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $signing "key" "publicKeyPath" "name" "BASYX_HISTORY_EVIDENCE_SIGNING_PUBLIC_KEY_PATH") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $signing "key" "required" "name" "BASYX_HISTORY_EVIDENCE_SIGNING_REQUIRED") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $integrityAnchor "key" "provider" "name" "BASYX_HISTORY_INTEGRITY_ANCHOR_PROVIDER") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $eventing "key" "enabled" "name" "BASYX_EVENTING_ENABLED") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $eventing "key" "format" "name" "BASYX_EVENTING_FORMAT") }}
+{{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $eventing "key" "sinks" "name" "BASYX_EVENTING_SINKS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $eventing "key" "outboxEnabled" "name" "BASYX_EVENTING_OUTBOX_ENABLED") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $eventing "key" "topicPrefix" "name" "BASYX_EVENTING_TOPIC_PREFIX") }}
+{{- end }}
+
+{{/*
 Render extra env entries from a key/value map.
 */}}
 {{- define "basyx.service.extraEnvMap" -}}
@@ -173,6 +326,7 @@ spec:
               value: {{ $values.service.port | quote }}
             - name: SERVER_CONTEXTPATH
               value: {{ index $root.Values.paths .component | quote }}
+            {{- include "basyx.serviceRuntimeEnv" (dict "root" $root "values" $values) | nindent 12 }}
             {{- range $key, $value := $values.environment | default dict }}
             - name: {{ $key }}
               value: {{ tpl (print $value) $root | quote }}
@@ -589,7 +743,7 @@ tls:
 {{- end }}
 
 {{- define "common.config.checksum" -}}
-{{- printf "%s\n%s\n%s\n" (printf "https://%s%s/realms/%s" .Values.host .Values.paths.keycloak .Values.keycloak.realm) (include "common.certs.sslCertDir" .) (toYaml .Values.environment.common) | sha256sum -}}
+{{- printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n" (printf "https://%s%s/realms/%s" .Values.host .Values.paths.keycloak .Values.keycloak.realm) (include "common.certs.sslCertDir" .) (toYaml .Values.environment.common) (toYaml .Values.general) (toYaml .Values.history) (toYaml .Values.eventing) (toYaml .Values.abac) | sha256sum -}}
 {{- end }}
 
 {{- define "common-database-config" -}}

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -247,16 +247,6 @@ Render service-local BaSyx runtime overrides as explicit container env values.
 {{- end }}
 
 {{/*
-Render extra env entries from a key/value map.
-*/}}
-{{- define "basyx.service.extraEnvMap" -}}
-{{- range $key, $val := . }}
-- name: {{ $key }}
-  value: {{ $val | quote }}
-{{- end }}
-{{- end }}
-
-{{/*
 Shared deployment template for the BaSyx Go backend services with common database/ABAC wiring.
 */}}
 {{- define "basyx.service.deployment" -}}

--- a/charts/basyx/templates/aas-discovery/deployment.yaml
+++ b/charts/basyx/templates/aas-discovery/deployment.yaml
@@ -8,6 +8,5 @@
   "selectorLabelsHelper" "basyx-aasDiscovery.selectorLabels"
   "serviceAccountHelper" "basyx-aasDiscovery.serviceAccountName"
   "containerName" "aas-discovery"
-  "extraEnv" (include "basyx.service.extraEnvMap" (.Values.aasDiscovery.environment | default dict))
 ) -}}
 {{- end }}

--- a/charts/basyx/templates/aas-discovery/deployment.yaml
+++ b/charts/basyx/templates/aas-discovery/deployment.yaml
@@ -1,108 +1,13 @@
 {{- if .Values.aasDiscovery.enabled -}}
-{{- $abac := dict "root" . "component" "aasDiscovery" "nameSuffix" "aas-discovery" -}}
-{{- $abacEnabled := eq (include "basyx.abac.enabled" $abac) "true" -}}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "basyx-aasDiscovery.fullname" . }}
-  labels:
-    {{- include "basyx-aasDiscovery.labels" . | nindent 4 }}
-spec:
-  replicas: {{ .Values.aasDiscovery.replicaCount }}
-  selector:
-    matchLabels:
-      {{- include "basyx-aasDiscovery.selectorLabels" . | nindent 6 }}
-  template:
-    metadata:
-      annotations:
-        {{- with .Values.aasDiscovery.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        checksum/common-config: {{ include "common.config.checksum" . }}
-        {{- if $abacEnabled }}
-        checksum/abac-config: {{ include "basyx.abac.checksum" $abac }}
-        {{- end }}
-      labels:
-        {{- include "basyx-aasDiscovery.labels" . | nindent 8 }}
-        {{- with .Values.aasDiscovery.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      {{- with .Values.aasDiscovery.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "basyx-aasDiscovery.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.aasDiscovery.podSecurityContext | nindent 8 }}
-
-      containers:
-        - name: aas-discovery
-          securityContext:
-            {{- toYaml .Values.aasDiscovery.securityContext | nindent 12 }}
-          image: {{ include "basyx.image" (dict "image" .Values.aasDiscovery.image "root" .) | quote }}
-          {{- if .Values.aasDiscovery.command }}
-          command:
-            {{- toYaml .Values.aasDiscovery.command | nindent 12 }}
-          {{- end }}
-          {{- if .Values.aasDiscovery.args }}
-          args:
-            {{- toYaml .Values.aasDiscovery.args | nindent 12 }}
-          {{- end }}
-          imagePullPolicy: {{ .Values.aasDiscovery.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.aasDiscovery.service.port }}
-              protocol: TCP
-          env:
-            {{- include "common-database-config" . | nindent 12 }}
-            - name: SERVER_PORT
-              value: "{{ .Values.aasDiscovery.service.port }}"
-            - name: SERVER_CONTEXTPATH
-              value: "{{ .Values.paths.aasDiscovery }}"
-            {{- include "basyx.abac.env" $abac | nindent 12 }}
-          envFrom:
-            - configMapRef:
-                name: {{ include "basyx-aasDiscovery.fullname" . }}-config
-            - secretRef:
-                name: {{ include "basyx.fullname" . }}-common-config
-          {{- with .Values.aasDiscovery.livenessProbe }}
-          livenessProbe:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
-          {{- with .Values.aasDiscovery.readinessProbe }}
-          readinessProbe:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
-          resources:
-            {{- toYaml .Values.aasDiscovery.resources | nindent 12 }}
-          {{- if or $.Values.aasDiscovery.volumeMounts $.Values.tls.enabled $abacEnabled }}
-          volumeMounts:
-            {{- with $.Values.aasDiscovery.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- include "common.certs.volumeMounts" . | nindent 12 }}
-            {{- include "basyx.abac.volumeMounts" $abac | nindent 12 }}
-          {{- end }}
-      {{- if or $.Values.aasDiscovery.volumes $.Values.tls.enabled $abacEnabled }}
-      volumes:
-        {{- with $.Values.aasDiscovery.volumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- include "common.certs.volume" . | nindent 8 }}
-        {{- include "basyx.abac.volume" $abac | nindent 8 }}
-      {{- end }}
-
-      {{- with .Values.aasDiscovery.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.aasDiscovery.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.aasDiscovery.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- include "basyx.service.deployment" (dict
+  "root" .
+  "component" "aasDiscovery"
+  "nameSuffix" "aas-discovery"
+  "fullnameHelper" "basyx-aasDiscovery.fullname"
+  "labelsHelper" "basyx-aasDiscovery.labels"
+  "selectorLabelsHelper" "basyx-aasDiscovery.selectorLabels"
+  "serviceAccountHelper" "basyx-aasDiscovery.serviceAccountName"
+  "containerName" "aas-discovery"
+  "extraEnv" (include "basyx.service.extraEnvMap" (.Values.aasDiscovery.environment | default dict))
+) -}}
 {{- end }}

--- a/charts/basyx/templates/aas-registry/deployment.yaml
+++ b/charts/basyx/templates/aas-registry/deployment.yaml
@@ -8,6 +8,5 @@
   "selectorLabelsHelper" "basyx-aasRegistry.selectorLabels"
   "serviceAccountHelper" "basyx-aasRegistry.serviceAccountName"
   "containerName" "aas-registry"
-  "extraEnv" (include "basyx.service.extraEnvMap" (.Values.aasRegistry.environment | default dict))
 ) -}}
 {{- end }}

--- a/charts/basyx/templates/company-lookup/deployment.yaml
+++ b/charts/basyx/templates/company-lookup/deployment.yaml
@@ -8,6 +8,5 @@
   "selectorLabelsHelper" "basyx-companyLookup.selectorLabels"
   "serviceAccountHelper" "basyx-companyLookup.serviceAccountName"
   "containerName" "company-lookup"
-  "extraEnv" (include "basyx.service.extraEnvMap" (.Values.companyLookup.environment | default dict))
 ) -}}
 {{- end }}

--- a/charts/basyx/templates/digital-twin-registry/deployment.yaml
+++ b/charts/basyx/templates/digital-twin-registry/deployment.yaml
@@ -8,6 +8,5 @@
   "selectorLabelsHelper" "basyx-digitalTwinRegistry.selectorLabels"
   "serviceAccountHelper" "basyx-digitalTwinRegistry.serviceAccountName"
   "containerName" "digital-twin-registry"
-  "extraEnv" (include "basyx.service.extraEnvMap" (.Values.digitalTwinRegistry.environment | default dict))
 ) -}}
 {{- end }}

--- a/charts/basyx/templates/secret.yaml
+++ b/charts/basyx/templates/secret.yaml
@@ -9,6 +9,7 @@ stringData:
   OIDC_ISSUER: "https://{{ .Values.host }}{{ .Values.paths.keycloak }}/realms/{{ .Values.keycloak.realm }}"
   # Include the system CA dir and optional custom CA mount for outbound TLS trust.
   SSL_CERT_DIR: {{ include "common.certs.sslCertDir" . | quote }}
+  {{- include "basyx.commonConfig.runtimeEnv" . | nindent 2 }}
   {{- range $key, $value := .Values.environment.common }}
   {{ $key }}: {{ tpl (print $value) $ | quote }}
   {{- end }}

--- a/charts/basyx/templates/tests/custom-ca-mount-test.yaml
+++ b/charts/basyx/templates/tests/custom-ca-mount-test.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "common.certs.customEnabled" .) "true" }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.19.0" "pullPolicy" "Always" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "Always" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/templates/tests/custom-ca-mount-test.yaml
+++ b/charts/basyx/templates/tests/custom-ca-mount-test.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "common.certs.customEnabled" .) "true" }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "Always" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "IfNotPresent" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/templates/tests/keycloak-realm-test.yaml
+++ b/charts/basyx/templates/tests/keycloak-realm-test.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.keycloak.enabled }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "Always" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "IfNotPresent" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/templates/tests/keycloak-realm-test.yaml
+++ b/charts/basyx/templates/tests/keycloak-realm-test.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.keycloak.enabled }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.19.0" "pullPolicy" "Always" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "Always" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -63,6 +63,69 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /aas-repository/health
 
+  - it: renders service-local runtime overrides for shared backend deployments
+    template: templates/aas-repository/deployment.yaml
+    set:
+      aasRepository.enabled: true
+      history.mode: audit
+      aasRepository.history.mode: api
+      aasRepository.history.evidence.enabled: true
+      aasRepository.eventing.topicPrefix: aas-repository-events
+      aasRepository.general.aasPreconfigPaths[0]: /aas/preconfigured
+      aasRepository.abac.policyFileImport: if_missing
+      aasRepository.abac.managementApi.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_HISTORY_MODE
+            value: api
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_HISTORY_EVIDENCE_ENABLED
+            value: "true"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_EVENTING_TOPIC_PREFIX
+            value: aas-repository-events
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERAL_AAS_PRECONFIG_PATHS
+            value: /aas/preconfigured
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ABAC_POLICY_FILE_IMPORT
+            value: if_missing
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ABAC_MANAGEMENT_API_ENABLED
+            value: "true"
+          count: 1
+
+  - it: lets raw service environment override structured service runtime config
+    template: templates/aas-repository/deployment.yaml
+    set:
+      aasRepository.enabled: true
+      aasRepository.history.mode: api
+      aasRepository.environment.BASYX_HISTORY_MODE: audit
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_HISTORY_MODE
+            value: audit
+          count: 1
+
   - it: renders numeric keycloak image tags cleanly
     template: templates/keycloak/deployment.yaml
     set:

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -175,6 +175,34 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /aas-discovery/health
 
+  - it: renders service-local runtime overrides for aas discovery
+    template: templates/aas-discovery/deployment.yaml
+    set:
+      aasDiscovery.enabled: true
+      history.mode: audit
+      aasDiscovery.history.mode: api
+      aasDiscovery.eventing.topicPrefix: discovery-events
+      aasDiscovery.general.trustProxyHeaders: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_HISTORY_MODE
+            value: api
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASYX_EVENTING_TOPIC_PREFIX
+            value: discovery-events
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERAL_TRUSTPROXYHEADERS
+            value: "true"
+          count: 1
+
   - it: probes the web ui at its configured base path
     template: templates/aas-web-gui/deployment.yaml
     set:

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -27,6 +27,97 @@ tests:
           path: stringData.OIDC_AUDIENCE
           value: discovery-service
 
+  - it: renders structured BaSyx runtime configuration into the common secret
+    template: templates/secret.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    set:
+      aasDiscovery.enabled: true
+      general.trustProxyHeaders: true
+      general.aasPreconfigPaths[0]: /app/preconfiguration
+      abac.policyFileImport: if_missing
+      abac.managementApi.enabled: true
+      history.mode: audit
+      history.fullSnapshotInterval: 5
+      history.immutability: postgres_guarded
+      history.auditIdentityMode: extended
+      history.evidence.enabled: true
+      history.evidence.provider: s3
+      history.evidence.bucket: basyx-history-evidence
+      history.evidence.prefix: history-evidence
+      history.evidence.endpoint: http://minio:9000
+      history.evidence.pathStyle: true
+      history.evidence.retentionMode: compliance
+      history.evidence.retentionDays: 7
+      eventing.topicPrefix: custom-basyx
+    asserts:
+      - equal:
+          path: stringData.GENERAL_TRUSTPROXYHEADERS
+          value: "true"
+      - equal:
+          path: stringData.GENERAL_AAS_PRECONFIG_PATHS
+          value: /app/preconfiguration
+      - equal:
+          path: stringData.ABAC_POLICY_FILE_IMPORT
+          value: if_missing
+      - equal:
+          path: stringData.ABAC_MANAGEMENT_API_ENABLED
+          value: "true"
+      - equal:
+          path: stringData.BASYX_HISTORY_MODE
+          value: audit
+      - equal:
+          path: stringData.BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL
+          value: "5"
+      - equal:
+          path: stringData.BASYX_HISTORY_IMMUTABILITY
+          value: postgres_guarded
+      - equal:
+          path: stringData.BASYX_AUDIT_IDENTITY_MODE
+          value: extended
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_ENABLED
+          value: "true"
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_PROVIDER
+          value: s3
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_BUCKET
+          value: basyx-history-evidence
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_PREFIX
+          value: history-evidence
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_ENDPOINT
+          value: http://minio:9000
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_PATH_STYLE
+          value: "true"
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_RETENTION_MODE
+          value: compliance
+      - equal:
+          path: stringData.BASYX_HISTORY_EVIDENCE_RETENTION_DAYS
+          value: "7"
+      - equal:
+          path: stringData.BASYX_EVENTING_TOPIC_PREFIX
+          value: custom-basyx
+
+  - it: lets environment.common override structured runtime configuration
+    template: templates/secret.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    set:
+      aasDiscovery.enabled: true
+      history.mode: audit
+      environment.common.BASYX_HISTORY_MODE: api
+    asserts:
+      - equal:
+          path: stringData.BASYX_HISTORY_MODE
+          value: api
+
   - it: renders the web ui infrastructure with keycloak issuer and client id
     template: templates/aas-web-gui/configmap-infrastructure.yaml
     set:

--- a/charts/basyx/tests/fixtures/invalid_history_audit_identity_mode.yaml
+++ b/charts/basyx/tests/fixtures/invalid_history_audit_identity_mode.yaml
@@ -1,0 +1,2 @@
+history:
+  auditIdentityMode: verbose

--- a/charts/basyx/tests/fixtures/invalid_history_evidence_write_timeout.yaml
+++ b/charts/basyx/tests/fixtures/invalid_history_evidence_write_timeout.yaml
@@ -1,0 +1,3 @@
+history:
+  evidence:
+    writeTimeoutSeconds: 0

--- a/charts/basyx/tests/fixtures/invalid_history_full_snapshot_interval.yaml
+++ b/charts/basyx/tests/fixtures/invalid_history_full_snapshot_interval.yaml
@@ -1,0 +1,2 @@
+history:
+  fullSnapshotInterval: 0

--- a/charts/basyx/tests/fixtures/invalid_history_immutability.yaml
+++ b/charts/basyx/tests/fixtures/invalid_history_immutability.yaml
@@ -1,0 +1,2 @@
+history:
+  immutability: append_only

--- a/charts/basyx/tests/fixtures/invalid_history_mode.yaml
+++ b/charts/basyx/tests/fixtures/invalid_history_mode.yaml
@@ -1,0 +1,2 @@
+history:
+  mode: enabled

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -86,7 +86,7 @@ tests:
           value: Never
       - equal:
           path: spec.containers[0].image
-          value: curlimages/curl:8.19.0
+          value: curlimages/curl:8.20.0
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: 'http://basyx-keycloak:9096/identity-management/realms/basyx'

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -23,3 +23,37 @@ tests:
       - failedTemplate:
           errorPattern: "paths.keycloak"
 
+  - it: fails when history mode is unsupported
+    values:
+      - fixtures/invalid_history_mode.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "history.mode"
+
+  - it: fails when history full snapshot interval is below one
+    values:
+      - fixtures/invalid_history_full_snapshot_interval.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "history.fullSnapshotInterval"
+
+  - it: fails when history immutability mode is unsupported
+    values:
+      - fixtures/invalid_history_immutability.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "history.immutability"
+
+  - it: fails when history audit identity mode is unsupported
+    values:
+      - fixtures/invalid_history_audit_identity_mode.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "history.auditIdentityMode"
+
+  - it: fails when history evidence write timeout is below one
+    values:
+      - fixtures/invalid_history_evidence_write_timeout.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "history.evidence.writeTimeoutSeconds"

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -1,6 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "definitions": {
+    "serviceRuntimeOverrides": {
+      "type": "object",
+      "properties": {
+        "general": { "$ref": "#/properties/general" },
+        "history": { "$ref": "#/properties/history" },
+        "eventing": { "$ref": "#/properties/eventing" },
+        "abac": {
+          "type": "object",
+          "properties": {
+            "policyFileImport": { "type": "string", "enum": ["", "always", "if_missing", "never"] },
+            "managementApi": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        "environment": { "type": "object" }
+      }
+    }
+  },
   "required": [
     "instanceName",
     "host",
@@ -209,6 +232,83 @@
         }
       }
     },
+    "general": {
+      "type": "object",
+      "properties": {
+        "enableImplicitCasts": { "type": "boolean" },
+        "enableDescriptorDebug": { "type": "boolean" },
+        "discoveryIntegration": { "type": "boolean" },
+        "enableCustomMiddlewareHeaderInjection": { "type": "boolean" },
+        "supportsSingularSupplementalSemanticId": { "type": "boolean" },
+        "aasRegistryIntegration": { "type": "boolean" },
+        "submodelRegistryIntegration": { "type": "boolean" },
+        "externalUrl": { "type": "string" },
+        "trustProxyHeaders": { "type": "boolean" },
+        "trustedProxyCIDRs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "uploadMaxSizeBytes": { "type": "integer", "minimum": 0 },
+        "aasPreconfigPaths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "history": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "enum": ["off", "api", "audit"] },
+        "retentionDays": { "type": "integer", "minimum": 0 },
+        "fullSnapshotInterval": { "type": "integer", "minimum": 1 },
+        "immutability": { "type": "string", "enum": ["none", "postgres_guarded", "external_anchor"] },
+        "auditIdentityMode": { "type": "string", "enum": ["none", "minimal", "extended"] },
+        "evidence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string" },
+            "bucket": { "type": "string" },
+            "prefix": { "type": "string" },
+            "region": { "type": "string" },
+            "endpoint": { "type": "string" },
+            "accessKeyId": { "type": "string" },
+            "secretAccessKey": { "type": "string" },
+            "pathStyle": { "type": "boolean" },
+            "retentionMode": { "type": "string" },
+            "retentionDays": { "type": "integer", "minimum": 0 },
+            "writeTimeoutSeconds": { "type": "integer", "minimum": 1 },
+            "signing": {
+              "type": "object",
+              "properties": {
+                "privateKeyPath": { "type": "string" },
+                "publicKeyPath": { "type": "string" },
+                "required": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        "integrityAnchor": {
+          "type": "object",
+          "properties": {
+            "provider": { "type": "string" }
+          }
+        }
+      }
+    },
+    "eventing": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "format": { "type": "string" },
+        "sinks": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "outboxEnabled": { "type": "boolean" },
+        "topicPrefix": { "type": "string" }
+      }
+    },
     "proxy": {
       "type": "object",
       "properties": {
@@ -295,6 +395,13 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "policyFileImport": { "type": "string", "enum": ["", "always", "if_missing", "never"] },
+        "managementApi": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "mountPath": { "type": "string" },
         "accessRulesFileName": { "type": "string" },
         "trustListFileName": { "type": "string" },
@@ -302,6 +409,14 @@
         "trustList": { "type": "string" }
       }
     },
+    "aasDiscovery": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "aasRegistry": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "aasRepository": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "submodelRegistry": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "submodelRepository": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "cdRepository": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "companyLookup": { "$ref": "#/definitions/serviceRuntimeOverrides" },
+    "digitalTwinRegistry": { "$ref": "#/definitions/serviceRuntimeOverrides" },
     "database": {
       "type": "object",
       "required": ["clusterName", "type", "instances", "storage"],

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -91,6 +91,62 @@ environment:
     OIDC_AUDIENCE: discovery-service
     ABAC_ENABLED: false
 
+# Shared BaSyx Go runtime configuration rendered into the common environment
+# for backend services. Explicit keys in environment.common override these
+# structured values.
+general:
+  enableImplicitCasts: true
+  enableDescriptorDebug: false
+  discoveryIntegration: false
+  enableCustomMiddlewareHeaderInjection: false
+  supportsSingularSupplementalSemanticId: false
+  aasRegistryIntegration: false
+  submodelRegistryIntegration: false
+  externalUrl: ""
+  trustProxyHeaders: false
+  trustedProxyCIDRs: []
+  uploadMaxSizeBytes: 0
+  # Comma-rendered into GENERAL_AAS_PRECONFIG_PATHS. Mount matching files or
+  # directories with the service-specific volumes/volumeMounts when used.
+  aasPreconfigPaths: []
+
+# AAS v3.2 history/audit runtime configuration. Defaults keep history disabled.
+history:
+  mode: "off"
+  retentionDays: 0
+  fullSnapshotInterval: 1
+  immutability: "none"
+  auditIdentityMode: "none"
+  evidence:
+    enabled: false
+    provider: "none"
+    bucket: ""
+    prefix: basyx-history-evidence
+    region: us-east-1
+    endpoint: ""
+    accessKeyId: ""
+    secretAccessKey: ""
+    pathStyle: false
+    retentionMode: ""
+    retentionDays: 0
+    writeTimeoutSeconds: 10
+    signing:
+      privateKeyPath: ""
+      publicKeyPath: ""
+      required: false
+  integrityAnchor:
+    provider: "none"
+
+# Future-compatible eventing settings. BaSyx Go currently fails fast when
+# event publishing or outbox processing is enabled before an implementation is
+# available.
+eventing:
+  enabled: false
+  format: cloudevents
+  sinks: []
+  outboxEnabled: false
+  topicPrefix: basyx
+
 
 # HTTP proxy settings for outbound connections from all services.
 # Set to empty string "" to disable. noProxy should include cluster-internal
@@ -415,6 +471,9 @@ submodelRepository:
     # Keep the Submodel Registry in sync when submodels are created, updated or deleted.
     GENERAL_SUBMODELREGISTRYINTEGRATION: true
     GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
+  general: {}
+  history: {}
+  eventing: {}
   resources: {}
     # limits:
     #   cpu: 500m
@@ -498,6 +557,10 @@ submodelRegistry:
         paths:
           - path: "{{ .Values.paths.submodelRegistry }}"
             pathType: ImplementationSpecific
+  environment: {}
+  general: {}
+  history: {}
+  eventing: {}
   resources: {}
     # limits:
     #   cpu: 500m
@@ -585,6 +648,9 @@ aasRegistry:
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
+  general: {}
+  history: {}
+  eventing: {}
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -680,6 +746,9 @@ digitalTwinRegistry:
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
+  general: {}
+  history: {}
+  eventing: {}
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -778,6 +847,9 @@ aasRepository:
     # Keep the AAS Registry in sync when AAS shells are created, updated or deleted.
     GENERAL_AASREGISTRYINTEGRATION: true
     GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.aasRepository }}"
+  general: {}
+  history: {}
+  eventing: {}
 
   resources: {}
     # limits:
@@ -866,6 +938,9 @@ cdRepository:
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
+  general: {}
+  history: {}
+  eventing: {}
 
   resources: {}
     # limits:
@@ -946,6 +1021,9 @@ companyLookup:
           - path: "{{ .Values.paths.companyLookup }}"
             pathType: ImplementationSpecific
   environment: {}
+  general: {}
+  history: {}
+  eventing: {}
   resources: {}
     # limits:
     #   cpu: 500m
@@ -1031,6 +1109,9 @@ aasDiscovery:
 
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
+  general: {}
+  history: {}
+  eventing: {}
   resources: {}
     # limits:
     #   cpu: 500m
@@ -1239,6 +1320,11 @@ database:
 # Individual services can override global ABAC settings via <service>.abac.*
 abac:
   enabled: false
+  # Startup import behavior for accessRulesFileName:
+  # "" uses the service default, otherwise one of always, if_missing, never.
+  policyFileImport: ""
+  managementApi:
+    enabled: false
   mountPath: /security_env
   accessRulesFileName: access-rules.json
   trustListFileName: trustlist.json

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -106,7 +106,7 @@ configurationService:
   enabled: true
   image:
     repository: eclipsebasyx/basyxconfigurationservice-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     digest: ""
   imagePullSecrets: []
@@ -163,14 +163,14 @@ keycloak:
   initJob:
     image:
       repository: peterevans/curl-jq
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
       tag: "1.0"
       digest: ""
   tests:
     realmCheck:
       image:
         repository: curlimages/curl
-        pullPolicy: Always
+        pullPolicy: IfNotPresent
         tag: 8.19.0
         digest: ""
   initialization:
@@ -288,7 +288,7 @@ keycloak:
   replicaCount: 1
   image:
     repository: keycloak/keycloak
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: 26.5
   imagePullSecrets: []
   nameOverride: "keycloak"
@@ -367,7 +367,7 @@ submodelRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/submodelrepository-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []
@@ -454,7 +454,7 @@ submodelRegistry:
   replicaCount: 1
   image:
     repository: eclipsebasyx/submodelregistry-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []
@@ -537,7 +537,7 @@ aasRegistry:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasregistry-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []
@@ -632,7 +632,7 @@ digitalTwinRegistry:
   replicaCount: 1
   image:
     repository: eclipsebasyx/digitaltwinregistry-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []
@@ -726,7 +726,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: SNAPSHOT
     digest: ""
     # Image tag is same as Chart App version
@@ -818,7 +818,7 @@ cdRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/conceptdescriptionrepository-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []
@@ -906,7 +906,7 @@ companyLookup:
   replicaCount: 1
   image:
     repository: eclipsebasyx/companylookup-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
     digest: ""
   imagePullSecrets: []
@@ -986,7 +986,7 @@ aasDiscovery:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasdiscovery-go
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: ""
   imagePullSecrets: []
   nameOverride: "aas-discovery"

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -727,7 +727,7 @@ aasRepository:
   image:
     repository: eclipsebasyx/aasrepository-go
     pullPolicy: IfNotPresent
-    tag: SNAPSHOT
+    tag: ""
     digest: ""
     # Image tag is same as Chart App version
   imagePullSecrets: []

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -227,7 +227,7 @@ keycloak:
       image:
         repository: curlimages/curl
         pullPolicy: IfNotPresent
-        tag: 8.19.0
+        tag: 8.20.0
         digest: ""
   initialization:
     userProfile:


### PR DESCRIPTION
## Summary

This PR updates the BaSyx-Go Helm chart after the initial `3.0.0-rc.1` release and prepares the next release candidate `3.0.0-rc.2`.

## Changes

- Bump chart version from `3.0.0-rc.1` to `3.0.0-rc.2`.
- Update BaSyx-Go chart `appVersion` to `1.0.0-rc.6`.
- Fix component image tag handling so BaSyx-Go services consistently use the chart `appVersion` where intended.
- Fix the AAS Repository default image tag configuration.
- Change BaSyx-Go backend service image pull policies to `IfNotPresent`, while keeping the independently versioned Web GUI behavior unchanged.
- Update Helm test/runtime helper images from `curlimages/curl:8.19.0` to `8.20.0`.
- Add structured runtime configuration values for `general`, `history`, and `eventing`.
- Add service-local runtime overrides for backend services.
- Add schema validation and Helm unittest coverage for history/audit settings.
- Document the new runtime configuration model, including per-service history overrides.
- Refactor AAS Discovery to use the shared backend deployment template, aligning it with the other BaSyx-Go services.

## Validation

The chart was validated with:

~~~bash
helm lint charts/basyx
helm unittest charts/basyx
~~~

Both checks pass locally.

## Runtime Smoke Test

Runtime-tested on Kubernetes with BaSyx-Go history enabled:

- `history.mode=off` produced no history rows.
- `history.mode=api` recorded AAS history snapshots.
- `history.mode=audit` with `postgres_guarded` recorded history snapshots and exposed them via the `$history` API.
- AAS Discovery successfully deployed through the shared deployment template.

## Operational Note

`postgres_guarded` enables a persistent database guard. Once enabled, services should keep compatible history/immutability settings, otherwise BaSyx-Go correctly refuses startup with a history guard conflict.