### PR TITLE
chore: release BaSyx Helm chart 3.0.0 with BaSyx-Go 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ keycloak:
 ```
 
 The chart can also create roles, clients, protocol mappers and users through `keycloak.initialization.*`.
+The default chart values initialize a generic admin user named `basyx.admin` with the password `changeit`.
+Override `keycloak.initialization.users` and `keycloak.secrets.*` before using Keycloak in any shared or production environment.
 
 ### BaSyx Services
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ database:
 
 ### BaSyx Configuration Service
 
-Current BaSyx Go snapshots require the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same CloudNativePG application secret as the runtime services.
+BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same CloudNativePG application secret as the runtime services.
 
 The Configuration Service image is versioned independently from the BaSyx runtime service images. Set `configurationService.image.tag` or, preferably for reproducible deployments, `configurationService.image.digest` explicitly when a schema migration image changes.
 
@@ -412,7 +412,7 @@ The default job runs as a Helm hook:
 configurationService:
   enabled: true
   image:
-    tag: SNAPSHOT
+    tag: "1.0.0"
   waitForDatabase:
     enabled: true
   hook:
@@ -466,7 +466,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    tag: SNAPSHOT
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -705,7 +705,7 @@ Enable the Web UI with:
 aasWebGui:
   enabled: true
   image:
-    tag: SNAPSHOT
+    tag: 0db02d0
 ```
 
 The Web UI infrastructure is rendered from `aasWebGui.infrastructureConfig`. The defaults derive service URLs from `host` and `paths.*`.

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.0.0-rc.3
-appVersion: "1.0.0-rc.6"
+version: 3.0.0
+appVersion: "1.0.0"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -25,7 +25,7 @@ tests:
           pattern: '"clientId":"basyx-ui"'
       - matchRegex:
           path: data["users.json"]
-          pattern: '"username":"d4e\.admin"'
+          pattern: '"username":"basyx\.admin"'
       - matchRegex:
           path: data["user-profile.json"]
           pattern: '"unmanagedAttributePolicy":"ADMIN_EDIT"'

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1256,7 +1256,7 @@ aasWebGui:
   image:
     repository: eclipsebasyx/aas-gui
     pullPolicy: Always
-    tag: SNAPSHOT
+    tag: 0db02d0
   imagePullSecrets: []
   nameOverride: "aas-gui"
   fullnameOverride: "aas-gui"

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -302,10 +302,10 @@ keycloak:
         serviceAccountsEnabled: true
 
     users:
-      - username: d4e.admin
+      - username: basyx.admin
         enabled: true
-        email: d4e_admin@example.com
-        firstName: D4E
+        email: basyx_admin@example.com
+        firstName: BaSyx
         lastName: Admin
         emailVerified: true
         attributes:
@@ -337,12 +337,12 @@ keycloak:
     name: "keycloak-credentials"
     # configures admin user for keycloak
     admin:
-      username: changme
-      password: changme
+      username: admin
+      password: changeit
     # configures client credentials for keycloak
     client:
       name: basyx-ui
-      clientPassword: changme
+      clientPassword: changeit
   replicaCount: 1
   image:
     repository: keycloak/keycloak


### PR DESCRIPTION
# chore: release BaSyx Helm chart 3.0.0 with BaSyx-Go 1.0.0

## Summary

This PR prepares the BaSyx Helm chart for the final `3.0.0` release using BaSyx-Go `1.0.0`.

## Changes

- Bump chart version from `3.0.0-rc.3` to `3.0.0`.
- Bump BaSyx-Go runtime `appVersion` from `1.0.0-rc.6` to `1.0.0`.
- Set the AAS Web UI default image tag to `0db02d0`.
- Update README examples from release-candidate/SNAPSHOT-oriented values to release-oriented values.
- Fix default Keycloak credentials from typo values to:
  - admin user: `admin` / `changeit`
  - client: `basyx-ui` / `changeit`
- Replace the default initialized Keycloak user `d4e.admin` with the generic `basyx.admin`.
- Document the default initialized Keycloak admin user in the README.

## Validation

```bash
helm lint charts/basyx
helm lint charts/basyx -f values/values.example.yaml
helm lint charts/basyx -f values/values.minimal.yaml
helm lint charts/basyx -f values/values.secured.example.yaml
helm unittest charts/basyx
```

The chart renders BaSyx-Go backend images with the chart `appVersion` (`1.0.0`) by default, while AAS Web UI uses its independently versioned image tag `0db02d0`.