### PR TITLE
Add Catena-X marker access example for BaSyx Go

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'charts/**'
+      - 'values/**'
       - '!**/README.md'
       - '.github/workflows/tests.yml'
       - 'lintconf.yaml'
@@ -16,6 +17,7 @@ on:
       - main
     paths:
       - 'charts/**'
+      - 'values/**'
       - '!**/README.md'
       - '.github/workflows/tests.yml'
       - 'lintconf.yaml'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The repository follows the common Helm multi-chart layout:
 
 ```text
 charts/basyx/           Helm chart for BaSyx Go
+examples/postman/       Postman collections for example setups
 values/                 Custom values examples and deployment overlays
 ```
 
@@ -917,6 +918,7 @@ charts/basyx/values.yaml            Default chart values
 charts/basyx/templates/             Kubernetes templates
 charts/basyx/tests/                 helm-unittest suites
 charts/basyx/config-files/          Chart-local files such as logos and optional certs
+examples/postman/                   Postman collections for example setups
 values/                             Custom values overlays
 ```
 
@@ -975,7 +977,7 @@ helm upgrade --install basyx charts/basyx \
   -f values/values.my-catena-x-environment.yaml
 ```
 
-The example initializes these demo users. All example passwords are `change-me`. The passwords are intentionally non-temporary in this example so the upstream Postman collection and command-line data loading examples can fetch OAuth2 password-grant tokens. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
+The example initializes these demo users. All example passwords are `change-me`. The Postman collection uses OAuth2 password-grant requests for demo data loading. Depending on your Keycloak policies, demo users may need to log in through the Web UI once and complete required account setup before those token requests succeed. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
 
 | User | Initial password | Purpose |
 | --- | --- | --- |
@@ -988,9 +990,38 @@ The upstream BaSyx Go marker example also contains demo data:
 - [shell-descriptor.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/shell-descriptor.json)
 - [public-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/public-submodel.json)
 - [restricted-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/restricted-submodel.json)
-- [BaSyx-Marker-Access.postman_collection.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json)
 
-Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment, for example with the provided Postman collection.
+Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment.
+
+This repository also includes a generic Postman collection for the Catena-X example:
+
+```text
+examples/postman/basyx-catena-x-marker-access.postman_collection.json
+```
+
+The collection contains the marker example payloads and uses the default ingress paths from `values/values.catena-x.example.yaml`.
+
+Before running it, import the collection into Postman and adjust the collection variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `baseUrl` | `https://basyx.example.com` | Public ingress base URL without a trailing slash. |
+| `realm` | `basyx` | Keycloak realm created by the example values. |
+| `clientId` | `basyx-ui` | OAuth2 client used for password-grant token requests. |
+| `providerUsername` | `catena-x.provider` | Demo provider user. |
+| `providerPassword` | `change-me` | Demo provider password. |
+| `partnerAUsername` | `catena-x.partner-a` | Demo consumer with `Edc-Bpn=BPN_COMPANY_001`. |
+| `partnerAPassword` | `change-me` | Demo partner A password. |
+| `partnerBUsername` | `catena-x.partner-b` | Demo consumer with `Edc-Bpn=BPN_COMPANY_002`. |
+| `partnerBPassword` | `change-me` | Demo partner B password. |
+
+Run the folders in this order:
+
+1. `Auth` fetches OAuth2 access tokens for the provider and both partners.
+2. `Setup - Write Example Data` removes old test objects if present, then creates the shell descriptor and both submodels.
+3. `Read - Provider`, `Read - Partner A`, `Read - Partner B` and `Read - Anonymous` exercise the marker-based read paths with different token claims.
+
+If Postman returns `invalid_grant` with `Account is not fully set up`, the Keycloak user still has a required action such as `UPDATE_PASSWORD`, `VERIFY_EMAIL` or user profile completion. Log in with that user through the Web UI or Keycloak account console first, complete the required setup, and run the `Auth` folder again.
 
 Do not upload these files through the generic Web UI JSON/UML import. That import expects AAS or AAS Environment payloads and will reject `shell-descriptor.json` with `no AAS imported`. The marker example files must be written to their component APIs instead: `shell-descriptor.json` to Digital Twin Registry and the submodel JSON files to Submodel Repository. If you use the example data outside localhost, adjust embedded endpoint URLs in the descriptor to match your ingress host and paths.
 

--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,8 @@ examples/postman/basyx-catena-x-marker-access.postman_collection.json
 
 The collection contains the marker example payloads and uses the default ingress paths from `values/values.catena-x.example.yaml`.
 
+In the Web UI infrastructure configuration, `submodelService.baseUrl` points to the Submodel Repository service root, for example `https://basyx.example.com/submodel-repo`. The Web UI appends concrete API paths such as `/submodels/{submodelId}` itself.
+
 Before running it, import the collection into Postman and adjust the collection variables:
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ charts/basyx/values.yaml
 Custom values files live outside the chart, for example:
 
 ```text
+values/values.catena-x.example.yaml
 values/values.example.yaml
 values/values.minimal.yaml
 values/values.secured.example.yaml
@@ -124,6 +125,9 @@ cp values/values.minimal.yaml values/values.my-minimal-environment.yaml
 
 # Secured deployment with Keycloak and ABAC.
 cp values/values.secured.example.yaml values/values.my-secured-environment.yaml
+
+# Catena-X oriented deployment with marker-based DTR and Submodel access.
+cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
 ```
 
 The unsecured example enables the core BaSyx Go services and the Web UI:
@@ -188,6 +192,8 @@ Use `values/values.minimal.yaml` when you want the BaSyx Go MinimalExample style
 
 For DPP API deployments, enable `dppApi` in your own values file. DPP commonly runs together with `aasEnvironment` and `aasWebGui`, but it is configured through the same service block pattern as the other optional BaSyx Go services.
 
+Use `values/values.catena-x.example.yaml` when you want a Catena-X oriented setup. It enables Keycloak, ABAC, Digital Twin Registry and Submodel Repository with BPN-based marker access rules.
+
 Do not publish production passwords or client secrets. For public examples, use placeholders and inject real credentials through your deployment pipeline or an external secret management solution.
 
 ## Render Before Installing
@@ -198,6 +204,7 @@ Always render the chart before the first install. This catches schema errors and
 helm lint charts/basyx -f values/values.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
+helm lint charts/basyx -f values/values.catena-x.example.yaml
 
 helm template basyx charts/basyx \
   -n basyx-custom \
@@ -285,6 +292,7 @@ With the default paths, services are exposed below one host:
 | Submodel Repository | `https://<host>/submodel-repo` or your custom override |
 | Concept Description Repository | `https://<host>/cd-repository` |
 | Company Lookup | `https://<host>/company-lookup/companies` |
+| Digital Twin Registry | `https://<host>/digital-twin-registry` |
 
 Company Lookup intentionally has no resource at the bare `/company-lookup` path. Use `/company-lookup/companies`, `/company-lookup/description`, `/company-lookup/swagger` or `/company-lookup/health`.
 
@@ -868,6 +876,7 @@ Run lint with custom values:
 helm lint charts/basyx -f values/values.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
+helm lint charts/basyx -f values/values.catena-x.example.yaml
 ```
 
 Runtime smoke tests after deployment:
@@ -919,6 +928,80 @@ Before publishing publicly:
 - Provide sanitized example values instead of production overlays.
 - Prefer fixed image tags or digests over mutable `SNAPSHOT` tags for reproducible deployments.
 - Review ABAC defaults and document deployment-specific rule sets outside the public chart when needed.
+
+## Catena-X Quick Start
+
+The Catena-X example values deploy the parts needed for marker-based Digital Twin access:
+
+- `digitalTwinRegistry` stores shell descriptors and filters them through AAS descriptor markers.
+- `submodelRepository` stores submodels and filters them through submodel and submodel-element markers.
+- `aasWebGui` is enabled with the `catena-x` infrastructure template, which uses `digitalTwinRegistry` and `submodelService` endpoints instead of the separate `Full` component set.
+- `keycloak` is enabled for a self-contained quick start and initializes demo users and token mappers.
+- `abac` is enabled globally, with service-local rules for Digital Twin Registry and Submodel Repository.
+
+Start from the example values:
+
+```bash
+cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
+```
+
+Edit at least these values before installing:
+
+```yaml
+host: basyx.example.com
+
+tls:
+  hosts:
+    - basyx.example.com
+
+keycloak:
+  secrets:
+    admin:
+      password: change-me
+    client:
+      clientPassword: change-me
+```
+
+Also replace the demo user passwords before using the file outside a throwaway test namespace.
+
+Then render and install:
+
+```bash
+helm lint charts/basyx -f values/values.my-catena-x-environment.yaml
+
+helm upgrade --install basyx charts/basyx \
+  -n basyx-catena-x \
+  --create-namespace \
+  -f values/values.my-catena-x-environment.yaml
+```
+
+The example initializes these demo users. All example passwords are `change-me`. The passwords are intentionally non-temporary in this example so the upstream Postman collection and command-line data loading examples can fetch OAuth2 password-grant tokens. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
+
+| User | Initial password | Purpose |
+| --- | --- | --- |
+| `catena-x.provider` | `change-me` | Data provider with `view_digital_twin`, `add_digital_twin`, `update_digital_twin` and `delete_digital_twin` role claims. |
+| `catena-x.partner-a` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_001` for marker-based read access tests. |
+| `catena-x.partner-b` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_002` for marker-based read access tests. |
+
+The upstream BaSyx Go marker example also contains demo data:
+
+- [shell-descriptor.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/shell-descriptor.json)
+- [public-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/public-submodel.json)
+- [restricted-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/restricted-submodel.json)
+- [BaSyx-Marker-Access.postman_collection.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json)
+
+Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment, for example with the provided Postman collection.
+
+Do not upload these files through the generic Web UI JSON/UML import. That import expects AAS or AAS Environment payloads and will reject `shell-descriptor.json` with `no AAS imported`. The marker example files must be written to their component APIs instead: `shell-descriptor.json` to Digital Twin Registry and the submodel JSON files to Submodel Repository. If you use the example data outside localhost, adjust embedded endpoint URLs in the descriptor to match your ingress host and paths.
+
+The marker rules follow the BaSyx Go marker access example:
+
+- `PUBLIC_READABLE` marks descriptors or submodels that can be read publicly.
+- Partner-specific visibility is based on the `Edc-Bpn` token claim.
+- Digital Twin Registry checks `specificAssetIds[].externalSubjectId.keys[].value` and `submodelDescriptors[].supplementalSemanticIds[].keys[].value`.
+- Submodel Repository checks `supplementalSemanticIds[].keys[].value` on submodels and submodel elements.
+
+For production Catena-X environments, prefer an external IAM or connector flow that issues a trustworthy `Edc-Bpn` token claim. Do not allow arbitrary external clients to set this claim through request headers. Header-to-claim injection should only be enabled behind a trusted ingress or connector mapping.
 
 ## References
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.1.0
+version: 3.1.1
 appVersion: "1.0.1"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.1.1
+version: 3.2.0
 appVersion: "1.0.1"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/aas-web-gui/deployment.yaml
+++ b/charts/basyx/templates/aas-web-gui/deployment.yaml
@@ -12,8 +12,15 @@ spec:
       {{- include "basyx-aasWebGui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.aasWebGui.podAnnotations }}
       annotations:
+        checksum/aas-web-gui-config: {{ include (print $.Template.BasePath "/aas-web-gui/configmap.yaml") . | sha256sum }}
+        {{- if .Values.aasWebGui.infrastructureConfig }}
+        checksum/aas-web-gui-infrastructure: {{ include (print $.Template.BasePath "/aas-web-gui/configmap-infrastructure.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.aasWebGui.logos }}
+        checksum/aas-web-gui-logos: {{ include (print $.Template.BasePath "/aas-web-gui/configmap-logos.yaml") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.aasWebGui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -18,6 +18,7 @@ The suites cover stable chart contracts such as:
 - ABAC mounts and rollout checksum annotations in backend deployments
 - optional AAS Environment deployment, ingress and ABAC wiring
 - optional DPP API deployment, ingress and ABAC wiring
+- Catena-X example values and marker-based ABAC wiring
 - common OIDC and ingress configuration
 - additional custom CA certificate mounts and trust-store wiring
 - runtime `helm test` hook for custom CA mount checks

--- a/charts/basyx/tests/abac_config_test.yaml
+++ b/charts/basyx/tests/abac_config_test.yaml
@@ -132,3 +132,50 @@ tests:
       - matchRegex:
           path: data["trustlist.json"]
           pattern: '"audience": "discovery-service"'
+
+  - it: renders Catena-X Digital Twin Registry ABAC rules from example values
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-digital-twin-registry-abac-config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"CLAIM": "Edc-Bpn"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"PUBLIC_READABLE"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '\$aasdesc#submodelDescriptors\[\]\.supplementalSemanticIds\[\]\.keys\[\]\.value'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/digital-twin-registry/lookup/shells"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"USEOBJECTS": \["all_shell_descriptors"\]'
+
+  - it: renders Catena-X Submodel Repository ABAC rules from example values
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-submodel-repository-abac-config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"CLAIM": "Edc-Bpn"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"PUBLIC_READABLE"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '\$sme#supplementalSemanticIds\[\]\.keys\[\]\.value'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/submodel-repo/query/submodels"'

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -3,6 +3,7 @@ release:
   name: basyx
 templates:
   - templates/secret.yaml
+  - templates/aas-web-gui/configmap.yaml
   - templates/aas-web-gui/configmap-infrastructure.yaml
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
@@ -155,6 +156,54 @@ tests:
       - matchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'baseUrl: https://basyx\.example\.com/aas-repository'
+
+  - it: renders Catena-X web ui infrastructure from example values
+    template: templates/aas-web-gui/configmap-infrastructure.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-aas-web-ui-infrastructure
+    asserts:
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'default: catena-x'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'template: catena-x'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'digitalTwinRegistry:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'baseUrl: https://basyx\.example\.com/digital-twin-registry'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'submodelService:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+      - notMatchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'aasRepository:'
+      - notMatchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'conceptDescriptionRepository:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'type: oauth2'
+
+  - it: renders Catena-X web ui runtime settings from example values
+    template: templates/aas-web-gui/configmap.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-aas-web-ui-config
+    asserts:
+      - equal:
+          path: data.START_PAGE_ROUTE_NAME
+          value: CatenaXplorer
 
   - it: mounts common config and custom ca into aas discovery
     template: templates/aas-discovery/deployment.yaml

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -5,6 +5,7 @@ templates:
   - templates/secret.yaml
   - templates/aas-web-gui/configmap.yaml
   - templates/aas-web-gui/configmap-infrastructure.yaml
+  - templates/aas-web-gui/configmap-logos.yaml
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
   - templates/aas-discovery/ingress.yaml
@@ -182,7 +183,7 @@ tests:
           pattern: 'submodelService:'
       - matchRegex:
           path: data["basyx-infra.yml"]
-          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo'
       - notMatchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'aasRepository:'
@@ -277,6 +278,12 @@ tests:
     set:
       aasWebGui.enabled: true
     asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-config"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-infrastructure"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-logos"]
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /aas-gui/

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -30,6 +30,39 @@ tests:
           path: data["user-profile.json"]
           pattern: '"unmanagedAttributePolicy":"ADMIN_EDIT"'
 
+  - it: renders Catena-X demo client and users for marker data loading
+    template: templates/keycloak-init-config.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-keycloak-init-config
+    asserts:
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"clientId":"basyx-ui"'
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"directAccessGrantsEnabled":true'
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"multivalued":"false"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"username":"catena-x\.provider"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"role":\["view_digital_twin add_digital_twin update_digital_twin delete_digital_twin"\]'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"value":"change-me"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"temporary":false'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"Edc-Bpn":\["BPN_COMPANY_001"\]'
+
   - it: renders keycloak init job with release-scoped resources and secret refs
     template: templates/keycloak-init-job.yaml
     set:

--- a/examples/postman/basyx-catena-x-marker-access.postman_collection.json
+++ b/examples/postman/basyx-catena-x-marker-access.postman_collection.json
@@ -1,0 +1,568 @@
+{
+  "info": {
+    "name": "BaSyx Catena-X Marker Access",
+    "description": "Postman collection for the BaSyx Go Catena-X marker access example. Set baseUrl to your ingress host, run the Auth folder first, then Setup - Write Example Data. The JSON payloads are based on BaSyxMarkerAccessExample and use the default paths from values.catena-x.example.yaml.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://basyx.example.com",
+      "type": "string"
+    },
+    {
+      "key": "realm",
+      "value": "basyx",
+      "type": "string"
+    },
+    {
+      "key": "clientId",
+      "value": "basyx-ui",
+      "type": "string"
+    },
+    {
+      "key": "providerUsername",
+      "value": "catena-x.provider",
+      "type": "string"
+    },
+    {
+      "key": "providerPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "partnerAUsername",
+      "value": "catena-x.partner-a",
+      "type": "string"
+    },
+    {
+      "key": "partnerAPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "partnerBUsername",
+      "value": "catena-x.partner-b",
+      "type": "string"
+    },
+    {
+      "key": "partnerBPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "aasIdBase64",
+      "value": "dXJuOmV4YW1wbGU6YWFzOnByb2R1Y3QtMDAx",
+      "type": "string"
+    },
+    {
+      "key": "publicSubmodelIdBase64",
+      "value": "dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+      "type": "string"
+    },
+    {
+      "key": "restrictedSubmodelIdBase64",
+      "value": "dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
+      "type": "string"
+    },
+    {
+      "key": "providerToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "partnerAToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "partnerBToken",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Get provider token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{providerUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{providerPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('provider token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('providerToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get partner A token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{partnerAUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{partnerAPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('partner A token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('partnerAToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get partner B token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{partnerBUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{partnerBPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('partner B token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('partnerBToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Setup - Write Example Data",
+      "item": [
+        {
+          "name": "Cleanup - Delete shell descriptor",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors/{{aasIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete shell descriptor is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Cleanup - Delete public submodel",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete public submodel is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Cleanup - Delete restricted submodel",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete restricted submodel is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post shell descriptor to DTR",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"idShort\":\"ProductTwin\",\"id\":\"urn:example:aas:product-001\",\"description\":[{\"language\":\"en\",\"text\":\"Public and partner-restricted submodel descriptors.\"}],\"globalAssetId\":\"urn:example:asset:product-001\",\"specificAssetIds\":[{\"name\":\"manufacturerPartId\",\"value\":\"PART-001\",\"externalSubjectId\":{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}},{\"name\":\"customerPartId\",\"value\":\"CUSTOMER-PART-001\",\"externalSubjectId\":{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}}],\"submodelDescriptors\":[{\"idShort\":\"PublicNameplate\",\"id\":\"urn:example:submodel:nameplate\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}],\"endpoints\":[{\"interface\":\"SUBMODEL-3.0\",\"protocolInformation\":{\"href\":\"{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}\",\"endpointProtocol\":\"HTTP\"}}]},{\"idShort\":\"RestrictedSerialPartTypization\",\"id\":\"urn:example:submodel:serial-part-typization\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}],\"endpoints\":[{\"interface\":\"SUBMODEL-3.0\",\"protocolInformation\":{\"href\":\"{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}\",\"endpointProtocol\":\"HTTP\"}}]}]}"
+            },
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('shell descriptor created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post public submodel",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"urn:example:submodel:nameplate\",\"idShort\":\"PublicNameplate\",\"modelType\":\"Submodel\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}],\"submodelElements\":[{\"idShort\":\"ManufacturerName\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"Example Corp\"}]}"
+            },
+            "url": "{{baseUrl}}/submodel-repo/submodels"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('public submodel created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post restricted submodel",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"urn:example:submodel:serial-part-typization\",\"idShort\":\"RestrictedSerialPartTypization\",\"modelType\":\"Submodel\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}],\"submodelElements\":[{\"idShort\":\"PublicPartType\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"PUBLIC-TYPE\"},{\"idShort\":\"PartnerSerialNumber\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"SECRET-001\"}]}"
+            },
+            "url": "{{baseUrl}}/submodel-repo/submodels"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('restricted submodel created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Read - Provider",
+      "item": [
+        {
+          "name": "Provider - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('provider can read descriptors', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Provider - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        },
+        {
+          "name": "Provider - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Partner A",
+      "item": [
+        {
+          "name": "Partner A - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Partner A - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        },
+        {
+          "name": "Partner A - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Partner B",
+      "item": [
+        {
+          "name": "Partner B - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerBToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Partner B - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerBToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Anonymous",
+      "item": [
+        {
+          "name": "Anonymous - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Anonymous - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -692,7 +692,7 @@ aasWebGui:
           digitalTwinRegistry:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
           submodelService:
-            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
         security:
           type: oauth2
           config:

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -1,0 +1,704 @@
+# Example values for a Catena-X oriented BaSyx Go deployment.
+#
+# This setup focuses on the marker-based Digital Twin Registry and Submodel
+# Repository access pattern used by the BaSyx Go Catena-X examples:
+#
+# - Digital Twin Registry visibility is controlled through
+#   specificAssetIds[].externalSubjectId.keys[].value and
+#   submodelDescriptors[].supplementalSemanticIds[].keys[].value.
+# - Submodel Repository visibility is controlled through
+#   supplementalSemanticIds[].keys[].value on submodels and submodel elements.
+# - PUBLIC_READABLE marks data that can be read without a matching BPN.
+# - BPN values are read from the token claim Edc-Bpn.
+#
+# Copy this file and adapt it for your own cluster:
+#
+#   cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
+#
+# Do not commit real passwords, client secrets or private certificate material.
+
+instanceName: catena-x
+host: basyx.example.com
+
+fullnameOverride: basyx
+
+tls:
+  enabled: true
+  hosts:
+    - basyx.example.com
+
+internal:
+  CACertificates:
+    trustStore:
+      useDefaultCAs: true
+      chartFileDirectory: ""
+      additionalCACertificates: ""
+  certificateIssuer:
+    name: internal-issuer
+    autocreateCa: true
+    autocreateCaSecretName: internal-issuer-ca
+    spec:
+      ca:
+        secretName: internal-issuer-ca
+
+ingress:
+  # Use this issuer when the chart should create and use its own internal CA.
+  issuer: internal-issuer
+
+database:
+  clusterName: basyx-database
+  instances: 1
+  storage:
+    size: 10Gi
+
+configurationService:
+  enabled: true
+
+environment:
+  common:
+    ABAC_ENABLED: true
+
+keycloak:
+  enabled: true
+  secrets:
+    admin:
+      username: admin
+      password: change-me
+    client:
+      name: basyx-ui
+      clientPassword: change-me
+  initialization:
+    roles:
+      - view_digital_twin
+      - add_digital_twin
+      - update_digital_twin
+      - delete_digital_twin
+    clients:
+      - clientId: basyx-ui
+        publicClient: true
+        standardFlowEnabled: true
+        implicitFlowEnabled: true
+        # Enabled for demo data loading with the upstream Postman collection or
+        # curl examples. Disable this in production and use authorization code
+        # flow or another trusted token issuing flow instead.
+        directAccessGrantsEnabled: true
+        redirectUris:
+          - "https://{{ .Values.host }}{{ .Values.paths.aasWebUiBasePath }}/*"
+        webOrigins:
+          - "+"
+        attributes:
+          post.logout.redirect.uris: "https://{{ .Values.host }}{{ .Values.paths.aasWebUiBasePath }}/*"
+          oauth2.device.authorization.grant.enabled: "true"
+        protocolMappers:
+          - name: Role Mapper
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              aggregate.attrs: "false"
+              introspection.token.claim: "true"
+              multivalued: "false"
+              userinfo.token.claim: "true"
+              user.attribute: role
+              id.token.claim: "true"
+              lightweight.claim: "false"
+              access.token.claim: "true"
+              claim.name: role
+              jsonType.label: String
+          - name: Edc BPN Mapper
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              aggregate.attrs: "false"
+              introspection.token.claim: "true"
+              multivalued: "false"
+              userinfo.token.claim: "true"
+              user.attribute: Edc-Bpn
+              id.token.claim: "true"
+              lightweight.claim: "false"
+              access.token.claim: "true"
+              claim.name: Edc-Bpn
+              jsonType.label: String
+          - name: discovery-service-aud-mapper
+            protocol: openid-connect
+            protocolMapper: oidc-audience-mapper
+            consentRequired: false
+            config:
+              included.client.audience: discovery-service
+              id.token.claim: "false"
+              lightweight.claim: "false"
+              introspection.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "false"
+      - clientId: discovery-service
+        serviceAccountsEnabled: true
+    users:
+      - username: catena-x.provider
+        enabled: true
+        email: provider@example.com
+        firstName: Catena-X
+        lastName: Provider
+        emailVerified: true
+        attributes:
+          # Keep role as one string value. BaSyx Go ABAC $contains evaluates
+          # strings and unwraps multi-value claims to their first entry.
+          role:
+            - view_digital_twin add_digital_twin update_digital_twin delete_digital_twin
+          Edc-Bpn:
+            - BPN_PROVIDER
+        roles:
+          - view_digital_twin
+          - add_digital_twin
+          - update_digital_twin
+          - delete_digital_twin
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+      - username: catena-x.partner-a
+        enabled: true
+        email: partner-a@example.com
+        firstName: Catena-X
+        lastName: Partner A
+        emailVerified: true
+        attributes:
+          Edc-Bpn:
+            - BPN_COMPANY_001
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+      - username: catena-x.partner-b
+        enabled: true
+        email: partner-b@example.com
+        firstName: Catena-X
+        lastName: Partner B
+        emailVerified: true
+        attributes:
+          Edc-Bpn:
+            - BPN_COMPANY_002
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+
+abac:
+  enabled: true
+
+digitalTwinRegistry:
+  enabled: true
+  general:
+    # Accept singular supplementalSemanticId input for compatibility with
+    # Catena-X/Tractus-X payload variants while emitting supplementalSemanticIds.
+    supportsSingularSupplementalSemanticId: true
+    # Keep this disabled for production. If a trusted ingress or connector maps
+    # Edc-Bpn into a token claim, the service does not need header injection.
+    enableCustomMiddlewareHeaderInjection: false
+  abac:
+    accessRules: |-
+      {
+        "AllAccessPermissionRules": {
+          "DEFATTRIBUTES": [
+            {
+              "name": "anonymous",
+              "attributes": [
+                { "GLOBAL": "ANONYMOUS" }
+              ]
+            }
+          ],
+          "DEFOBJECTS": [
+            {
+              "name": "all_routes",
+              "objects": [
+                { "ROUTE": "*" }
+              ]
+            },
+            {
+              "name": "all_shell_descriptors",
+              "objects": [
+                { "DESCRIPTOR": "$aasdesc(\"*\")" }
+              ]
+            },
+            {
+              "name": "asset_links",
+              "objects": [
+                { "ROUTE": "/lookup/shells" },
+                { "ROUTE": "/lookup/shellsByAssetLink" },
+                { "ROUTE": "{{ .Values.paths.digitalTwinRegistry }}/lookup/shells" },
+                { "ROUTE": "{{ .Values.paths.digitalTwinRegistry }}/lookup/shellsByAssetLink" }
+              ]
+            }
+          ],
+          "DEFACLS": [
+            {
+              "name": "read",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["READ"],
+                "ACCESS": "ALLOW"
+              }
+            },
+            {
+              "name": "write",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["CREATE", "UPDATE", "DELETE"],
+                "ACCESS": "ALLOW"
+              }
+            }
+          ],
+          "DEFFORMULAS": [
+            {
+              "name": "data_provider_read",
+              "formula": {
+                "$contains": [
+                  { "$attribute": { "CLAIM": "role" } },
+                  { "$strVal": "view_digital_twin" }
+                ]
+              }
+            },
+            {
+              "name": "data_provider",
+              "formula": {
+                "$or": [
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "add_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "update_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "delete_digital_twin" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_match",
+              "formula": {
+                "$eq": [
+                  { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                  { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_descriptor_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_descriptor_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "rules": [
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["all_shell_descriptors", "asset_links"],
+              "USEFORMULA": "data_provider_read"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_routes"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_shell_descriptors"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["all_shell_descriptors"],
+              "USEFORMULA": "aas_bpn_or_public",
+              "FILTERLIST": [
+                { "FRAGMENT": "$aasdesc#administration", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#displayName", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#description", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#assetKind", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#assetType", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#globalAssetId", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#idShort", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#specificAssetIds[]", "USEFORMULA": "aas_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#specificAssetIds[].externalSubjectId.keys[]", "USEFORMULA": "aas_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[]", "USEFORMULA": "submodel_descriptor_bpn_or_public", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[]", "USEFORMULA": "submodel_descriptor_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_descriptor_bpn_or_public_with_claim", "MATCH": true }
+              ]
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["asset_links"],
+              "USEFORMULA": "aas_bpn_or_public"
+            }
+          ]
+        }
+      }
+
+submodelRepository:
+  enabled: true
+  environment:
+    # The Catena-X marker example uses the Submodel Repository directly without
+    # a separate Submodel Registry.
+    GENERAL_SUBMODELREGISTRYINTEGRATION: false
+    GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
+  general:
+    # Keep this disabled for production. Use a signed token claim or a trusted
+    # ingress/connector mapping for Edc-Bpn instead.
+    enableCustomMiddlewareHeaderInjection: false
+  abac:
+    accessRules: |-
+      {
+        "AllAccessPermissionRules": {
+          "DEFATTRIBUTES": [
+            {
+              "name": "anonymous",
+              "attributes": [
+                { "GLOBAL": "ANONYMOUS" }
+              ]
+            }
+          ],
+          "DEFOBJECTS": [
+            {
+              "name": "all_routes",
+              "objects": [
+                { "ROUTE": "*" }
+              ]
+            },
+            {
+              "name": "submodel_routes",
+              "objects": [
+                { "ROUTE": "/submodels" },
+                { "ROUTE": "/submodels/*" },
+                { "ROUTE": "/submodels/*/submodel-elements" },
+                { "ROUTE": "/submodels/*/submodel-elements/*" },
+                { "ROUTE": "/query/submodels" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*/submodel-elements" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*/submodel-elements/*" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/query/submodels" }
+              ]
+            }
+          ],
+          "DEFACLS": [
+            {
+              "name": "read",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["READ"],
+                "ACCESS": "ALLOW"
+              }
+            },
+            {
+              "name": "write",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["CREATE", "UPDATE", "DELETE"],
+                "ACCESS": "ALLOW"
+              }
+            }
+          ],
+          "DEFFORMULAS": [
+            {
+              "name": "data_provider_read",
+              "formula": {
+                "$contains": [
+                  { "$attribute": { "CLAIM": "role" } },
+                  { "$strVal": "view_digital_twin" }
+                ]
+              }
+            },
+            {
+              "name": "data_provider",
+              "formula": {
+                "$or": [
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "add_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "update_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "delete_digital_twin" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_element_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_element_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "rules": [
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["submodel_routes"],
+              "USEFORMULA": "data_provider_read"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_routes"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["submodel_routes"],
+              "USEFORMULA": "submodel_bpn_or_public",
+              "FILTERLIST": [
+                { "FRAGMENT": "$sm#supplementalSemanticIds[]", "USEFORMULA": "submodel_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sm#supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sme", "USEFORMULA": "submodel_element_bpn_or_public", "MATCH": true },
+                { "FRAGMENT": "$sme#supplementalSemanticIds[]", "USEFORMULA": "submodel_element_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sme#supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_element_bpn_or_public_with_claim", "MATCH": true }
+              ]
+            }
+          ]
+        }
+      }
+
+aasDiscovery:
+  enabled: false
+
+aasRegistry:
+  enabled: false
+
+aasRepository:
+  enabled: false
+
+aasEnvironment:
+  enabled: false
+
+dppApi:
+  enabled: false
+
+submodelRegistry:
+  enabled: false
+
+cdRepository:
+  enabled: false
+
+aasWebGui:
+  enabled: true
+  environment:
+    START_PAGE_ROUTE_NAME: CatenaXplorer
+  infrastructureConfig:
+    infrastructures:
+      main: null
+      default: catena-x
+      catena-x:
+        name: "Catena-X BaSyx Go {{ .Values.instanceName }}"
+        template: catena-x
+        components:
+          digitalTwinRegistry:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
+          submodelService:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+        security:
+          type: oauth2
+          config:
+            flow: auth_code
+            issuer: "https://{{ .Values.host }}{{ .Values.paths.keycloak }}/realms/{{ .Values.keycloak.realm }}"
+            clientId: "{{ .Values.keycloak.secrets.client.name }}"
+
+companyLookup:
+  enabled: false


### PR DESCRIPTION
## Summary

This PR addresses #75 by adding a Catena-X oriented example configuration for the BaSyx Go Helm chart.

The new example focuses on marker-based access control using Digital Twin Registry and Submodel Repository. It demonstrates how `PUBLIC_READABLE` markers and `Edc-Bpn` token claims can be used to control descriptor and submodel visibility.

## Changes

- Add `values/values.catena-x.example.yaml`.
- Configure Digital Twin Registry and Submodel Repository for marker-based ABAC.
- Configure Keycloak demo users for provider and partner access scenarios.
- Configure AAS Web UI with the `catena-x` infrastructure template.
- Add a generic Postman collection for loading and testing marker example data.
- Document the Catena-X setup, demo users, Postman workflow, expected public marker behavior, and first-login password setup.
- Fix the Catena-X Web UI submodel service configuration by pointing `submodelService.baseUrl` to the Submodel Repository service root.
- Add Web UI deployment checksum annotations so infrastructure ConfigMap changes trigger a rollout.
- Extend chart tests for Catena-X ABAC, Keycloak mapper setup, UI configuration, and Web UI rollout checks.
- Bump the chart version to `3.2.0`.

## Validation

```bash
helm lint charts/basyx -f values/values.catena-x.example.yaml
helm unittest charts/basyx
```

## Related Issue

Closes #75