### PR TITLE
Add BaSyx Go server timeout configuration and update 1.0.2 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ The default job runs as a Helm hook:
 configurationService:
   enabled: true
   image:
-    tag: "1.0.1"
+    tag: "1.0.2"
   waitForDatabase:
     enabled: true
   hook:
@@ -474,7 +474,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    tag: "1.0.1"
+    tag: "1.0.2"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -496,7 +496,7 @@ Supported service blocks:
 - `companyLookup`
 - `digitalTwinRegistry`
 
-Most service blocks support `enabled`, `replicaCount`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `abac` overrides.
+Most service blocks support `enabled`, `replicaCount`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `server`, `history`, `eventing`, `general` and `abac` overrides.
 
 `aasEnvironment` uses the `eclipsebasyx/aasenvironment-go` image and defaults to service port `8082`. It can be deployed as a single BaSyx Go API endpoint backed by the chart's PostgreSQL database and Configuration Service. It enables AAS Registry, Submodel Registry and Discovery integration by default:
 
@@ -600,6 +600,13 @@ general:
   bulkBatchLimit: 1000
   aasPreconfigPaths: []
 
+server:
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
+
 history:
   mode: "off"
   immutability: "none"
@@ -626,6 +633,10 @@ history:
   mode: "off"
 
 aasRepository:
+  server:
+    readTimeoutSeconds: 600
+    writeTimeoutSeconds: 600
+    shutdownTimeoutSeconds: 30
   history:
     mode: audit
     immutability: postgres_guarded
@@ -708,6 +719,29 @@ Raw environment maps are the escape hatch and take precedence over structured va
 
 `aasRepository` and `submodelRepository` already set registry integration related values in their service-local `environment` maps by default. Override these service-local values only when you intentionally want different registry synchronization behavior.
 
+#### Server Runtime Values
+
+The `server` block controls BaSyx Go HTTP server timeouts. All timeout values are configured in seconds and must be greater than `0`.
+
+| Value | Rendered environment variable | Default | Description |
+| --- | --- | --- | --- |
+| `server.readHeaderTimeoutSeconds` | `SERVER_READ_HEADER_TIMEOUT_SECONDS` | `15` | Maximum time to read HTTP request headers. |
+| `server.readTimeoutSeconds` | `SERVER_READ_TIMEOUT_SECONDS` | `300` | Maximum time to read a full HTTP request including the body. |
+| `server.writeTimeoutSeconds` | `SERVER_WRITE_TIMEOUT_SECONDS` | `300` | Maximum time to write an HTTP response. |
+| `server.idleTimeoutSeconds` | `SERVER_IDLE_TIMEOUT_SECONDS` | `60` | Maximum keep-alive idle time before waiting for the next request ends. |
+| `server.shutdownTimeoutSeconds` | `SERVER_SHUTDOWN_TIMEOUT_SECONDS` | `10` | Maximum graceful shutdown time for in-flight requests after the service receives a termination signal. |
+
+As with `general`, `history`, `eventing` and `abac`, these values can be set globally or overridden per backend service:
+
+```yaml
+server:
+  readTimeoutSeconds: 300
+
+aasRepository:
+  server:
+    readTimeoutSeconds: 900
+```
+
 #### History, Audit And Evidence Values
 
 | Value | Rendered environment variable | Description |
@@ -762,7 +796,7 @@ Enable the Web UI with:
 aasWebGui:
   enabled: true
   image:
-    tag: 0db02d0
+    tag: v2-260707
 ```
 
 The Web UI infrastructure is rendered from `aasWebGui.infrastructureConfig`. The defaults derive service URLs from `host` and `paths.*`.

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.1.0
-appVersion: "1.0.1"
+version: 3.2.0
+appVersion: "1.0.2"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -149,6 +149,7 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- $root := . -}}
 {{- $common := .Values.environment.common | default dict -}}
 {{- $general := .Values.general | default dict -}}
+{{- $server := .Values.server | default dict -}}
 {{- $history := .Values.history | default dict -}}
 {{- $evidence := dig "evidence" (dict) $history -}}
 {{- $signing := dig "signing" (dict) $evidence -}}
@@ -168,6 +169,11 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_UPLOADMAXSIZEBYTES" "value" (dig "uploadMaxSizeBytes" 0 $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_BULK_BATCH_LIMIT" "value" (dig "bulkBatchLimit" 1000 $general)) }}
 {{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "GENERAL_AAS_PRECONFIG_PATHS" "value" (dig "aasPreconfigPaths" (list) $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_READ_HEADER_TIMEOUT_SECONDS" "value" (dig "readHeaderTimeoutSeconds" 15 $server)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_READ_TIMEOUT_SECONDS" "value" (dig "readTimeoutSeconds" 300 $server)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_WRITE_TIMEOUT_SECONDS" "value" (dig "writeTimeoutSeconds" 300 $server)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_IDLE_TIMEOUT_SECONDS" "value" (dig "idleTimeoutSeconds" 60 $server)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_SHUTDOWN_TIMEOUT_SECONDS" "value" (dig "shutdownTimeoutSeconds" 10 $server)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "ABAC_POLICY_FILE_IMPORT" "value" (dig "policyFileImport" "" $abac)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "ABAC_POLICY_SCOPE" "value" (dig "policyScope" "" $abac)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "ABAC_MANAGEMENT_API_ENABLED" "value" (dig "managementApi" "enabled" false $abac)) }}
@@ -207,6 +213,7 @@ Render service-local BaSyx runtime overrides as explicit container env values.
 {{- $values := .values | default dict -}}
 {{- $environment := $values.environment | default dict -}}
 {{- $general := $values.general | default dict -}}
+{{- $server := $values.server | default dict -}}
 {{- $history := $values.history | default dict -}}
 {{- $evidence := $history.evidence | default dict -}}
 {{- $signing := $evidence.signing | default dict -}}
@@ -227,6 +234,11 @@ Render service-local BaSyx runtime overrides as explicit container env values.
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "uploadMaxSizeBytes" "name" "GENERAL_UPLOADMAXSIZEBYTES") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "bulkBatchLimit" "name" "GENERAL_BULK_BATCH_LIMIT") }}
 {{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $general "key" "aasPreconfigPaths" "name" "GENERAL_AAS_PRECONFIG_PATHS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "readHeaderTimeoutSeconds" "name" "SERVER_READ_HEADER_TIMEOUT_SECONDS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "readTimeoutSeconds" "name" "SERVER_READ_TIMEOUT_SECONDS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "writeTimeoutSeconds" "name" "SERVER_WRITE_TIMEOUT_SECONDS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "idleTimeoutSeconds" "name" "SERVER_IDLE_TIMEOUT_SECONDS") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "shutdownTimeoutSeconds" "name" "SERVER_SHUTDOWN_TIMEOUT_SECONDS") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $abac "key" "policyFileImport" "name" "ABAC_POLICY_FILE_IMPORT") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $abac "key" "policyScope" "name" "ABAC_POLICY_SCOPE") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $abacManagementApi "key" "enabled" "name" "ABAC_MANAGEMENT_API_ENABLED") }}

--- a/charts/basyx/templates/configuration-service-job.yaml
+++ b/charts/basyx/templates/configuration-service-job.yaml
@@ -53,9 +53,9 @@ spec:
             - /bin/sh
             - -ec
             - |
-              end=$((SECONDS + {{ .Values.configurationService.waitForDatabase.timeoutSeconds }}))
+              end=$(($(date +%s) + {{ .Values.configurationService.waitForDatabase.timeoutSeconds }}))
               until pg_isready -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d "${POSTGRES_DBNAME}"; do
-                if [ "${SECONDS}" -ge "${end}" ]; then
+                if [ "$(date +%s)" -ge "${end}" ]; then
                   echo "Timed out waiting for PostgreSQL at ${POSTGRES_HOST}:${POSTGRES_PORT}" >&2
                   exit 1
                 fi

--- a/charts/basyx/templates/tests/custom-ca-mount-test.yaml
+++ b/charts/basyx/templates/tests/custom-ca-mount-test.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "common.certs.customEnabled" .) "true" }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "IfNotPresent" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.21.0" "pullPolicy" "IfNotPresent" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/templates/tests/keycloak-realm-test.yaml
+++ b/charts/basyx/templates/tests/keycloak-realm-test.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.keycloak.enabled }}
-{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.20.0" "pullPolicy" "IfNotPresent" "digest" "" }}
+{{- $defaultImage := dict "repository" "curlimages/curl" "tag" "8.21.0" "pullPolicy" "IfNotPresent" "digest" "" }}
 {{- $configuredImage := dict }}
 {{- with .Values.keycloak }}
 {{- with .tests }}

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -75,6 +75,8 @@ tests:
       aasRepository.eventing.topicPrefix: aas-repository-events
       aasRepository.general.aasPreconfigPaths[0]: /aas/preconfigured
       aasRepository.general.bulkBatchLimit: 250
+      aasRepository.server.readTimeoutSeconds: 120
+      aasRepository.server.shutdownTimeoutSeconds: 20
       aasRepository.abac.policyFileImport: if_missing
       aasRepository.abac.policyScope: aas-repository-scope
       aasRepository.abac.managementApi.enabled: true
@@ -112,6 +114,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SERVER_READ_TIMEOUT_SECONDS
+            value: "120"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVER_SHUTDOWN_TIMEOUT_SECONDS
+            value: "20"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: ABAC_POLICY_FILE_IMPORT
             value: if_missing
           count: 1
@@ -136,6 +150,8 @@ tests:
       aasRepository.environment.BASYX_HISTORY_MODE: audit
       aasRepository.general.bulkBatchLimit: 250
       aasRepository.environment.GENERAL_BULK_BATCH_LIMIT: 100
+      aasRepository.server.readTimeoutSeconds: 120
+      aasRepository.environment.SERVER_READ_TIMEOUT_SECONDS: 90
       aasRepository.abac.policyScope: structured-scope
       aasRepository.environment.ABAC_POLICY_SCOPE: raw-scope
     asserts:
@@ -150,6 +166,12 @@ tests:
           content:
             name: GENERAL_BULK_BATCH_LIMIT
             value: "100"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVER_READ_TIMEOUT_SECONDS
+            value: "90"
           count: 1
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -28,6 +28,21 @@ tests:
       - equal:
           path: stringData.OIDC_AUDIENCE
           value: discovery-service
+      - equal:
+          path: stringData.SERVER_READ_HEADER_TIMEOUT_SECONDS
+          value: "15"
+      - equal:
+          path: stringData.SERVER_READ_TIMEOUT_SECONDS
+          value: "300"
+      - equal:
+          path: stringData.SERVER_WRITE_TIMEOUT_SECONDS
+          value: "300"
+      - equal:
+          path: stringData.SERVER_IDLE_TIMEOUT_SECONDS
+          value: "60"
+      - equal:
+          path: stringData.SERVER_SHUTDOWN_TIMEOUT_SECONDS
+          value: "10"
 
   - it: renders structured BaSyx runtime configuration into the common secret
     template: templates/secret.yaml
@@ -39,6 +54,11 @@ tests:
       general.trustProxyHeaders: true
       general.bulkBatchLimit: 500
       general.aasPreconfigPaths[0]: /app/preconfiguration
+      server.readHeaderTimeoutSeconds: 20
+      server.readTimeoutSeconds: 600
+      server.writeTimeoutSeconds: 700
+      server.idleTimeoutSeconds: 80
+      server.shutdownTimeoutSeconds: 30
       abac.policyFileImport: if_missing
       abac.policyScope: shared-policy-scope
       abac.managementApi.enabled: true
@@ -65,6 +85,21 @@ tests:
       - equal:
           path: stringData.GENERAL_BULK_BATCH_LIMIT
           value: "500"
+      - equal:
+          path: stringData.SERVER_READ_HEADER_TIMEOUT_SECONDS
+          value: "20"
+      - equal:
+          path: stringData.SERVER_READ_TIMEOUT_SECONDS
+          value: "600"
+      - equal:
+          path: stringData.SERVER_WRITE_TIMEOUT_SECONDS
+          value: "700"
+      - equal:
+          path: stringData.SERVER_IDLE_TIMEOUT_SECONDS
+          value: "80"
+      - equal:
+          path: stringData.SERVER_SHUTDOWN_TIMEOUT_SECONDS
+          value: "30"
       - equal:
           path: stringData.ABAC_POLICY_FILE_IMPORT
           value: if_missing
@@ -125,6 +160,8 @@ tests:
       environment.common.BASYX_HISTORY_MODE: api
       general.bulkBatchLimit: 500
       environment.common.GENERAL_BULK_BATCH_LIMIT: 250
+      server.readTimeoutSeconds: 600
+      environment.common.SERVER_READ_TIMEOUT_SECONDS: 120
       abac.policyScope: structured-scope
       environment.common.ABAC_POLICY_SCOPE: raw-scope
     asserts:
@@ -134,6 +171,9 @@ tests:
       - equal:
           path: stringData.GENERAL_BULK_BATCH_LIMIT
           value: "250"
+      - equal:
+          path: stringData.SERVER_READ_TIMEOUT_SECONDS
+          value: "120"
       - equal:
           path: stringData.ABAC_POLICY_SCOPE
           value: raw-scope

--- a/charts/basyx/tests/configuration_service_test.yaml
+++ b/charts/basyx/tests/configuration_service_test.yaml
@@ -32,10 +32,16 @@ tests:
           value: wait-for-database
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
+          value: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "pg_isready"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "date \\+%s"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SECONDS"
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "^eclipsebasyx/basyxconfigurationservice-go:[^:]+$"

--- a/charts/basyx/tests/fixtures/invalid_server_timeout.yaml
+++ b/charts/basyx/tests/fixtures/invalid_server_timeout.yaml
@@ -1,0 +1,2 @@
+server:
+  readTimeoutSeconds: 0

--- a/charts/basyx/tests/fixtures/invalid_service_server_timeout.yaml
+++ b/charts/basyx/tests/fixtures/invalid_service_server_timeout.yaml
@@ -1,0 +1,3 @@
+aasRepository:
+  server:
+    shutdownTimeoutSeconds: 0

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -86,7 +86,7 @@ tests:
           value: Never
       - equal:
           path: spec.containers[0].image
-          value: curlimages/curl:8.20.0
+          value: curlimages/curl:8.21.0
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: 'http://basyx-keycloak:9096/identity-management/realms/basyx'

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -79,6 +79,20 @@ tests:
       - failedTemplate:
           errorPattern: "general.bulkBatchLimit"
 
+  - it: fails when server timeout is below one
+    values:
+      - fixtures/invalid_server_timeout.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "server.readTimeoutSeconds"
+
+  - it: fails when service-local server timeout is below one
+    values:
+      - fixtures/invalid_service_server_timeout.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.server.shutdownTimeoutSeconds"
+
   - it: fails when ABAC policy scope contains unsupported characters
     values:
       - fixtures/invalid_abac_policy_scope.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -6,6 +6,7 @@
       "type": "object",
       "properties": {
         "general": { "$ref": "#/properties/general" },
+        "server": { "$ref": "#/properties/server" },
         "history": { "$ref": "#/properties/history" },
         "eventing": { "$ref": "#/properties/eventing" },
         "abac": {
@@ -263,6 +264,16 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         }
+      }
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "readHeaderTimeoutSeconds": { "type": "integer", "minimum": 1 },
+        "readTimeoutSeconds": { "type": "integer", "minimum": 1 },
+        "writeTimeoutSeconds": { "type": "integer", "minimum": 1 },
+        "idleTimeoutSeconds": { "type": "integer", "minimum": 1 },
+        "shutdownTimeoutSeconds": { "type": "integer", "minimum": 1 }
       }
     },
     "history": {

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -113,6 +113,15 @@ general:
   # directories with the service-specific volumes/volumeMounts when used.
   aasPreconfigPaths: []
 
+# Shared BaSyx Go HTTP server timeout configuration. Values are rendered into
+# SERVER_* environment variables for backend services and must be greater than 0.
+server:
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
+
 # AAS v3.2 history/audit runtime configuration. Defaults keep history disabled.
 history:
   mode: "off"
@@ -176,7 +185,7 @@ configurationService:
     image:
       repository: ghcr.io/cloudnative-pg/postgresql
       pullPolicy: IfNotPresent
-      tag: "18.3-system-trixie"
+      tag: "18.4-system-trixie"
       digest: ""
     intervalSeconds: 5
     timeoutSeconds: 600
@@ -230,7 +239,7 @@ keycloak:
       image:
         repository: curlimages/curl
         pullPolicy: IfNotPresent
-        tag: 8.20.0
+        tag: 8.21.0
         digest: ""
   initialization:
     userProfile:
@@ -475,6 +484,7 @@ submodelRepository:
     GENERAL_SUBMODELREGISTRYINTEGRATION: true
     GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
   general: {}
+  server: {}
   history: {}
   eventing: {}
   resources: {}
@@ -562,6 +572,7 @@ submodelRegistry:
             pathType: ImplementationSpecific
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
   resources: {}
@@ -652,6 +663,7 @@ aasRegistry:
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
 
@@ -750,6 +762,7 @@ digitalTwinRegistry:
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
 
@@ -851,6 +864,7 @@ aasRepository:
     GENERAL_AASREGISTRYINTEGRATION: true
     GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.aasRepository }}"
   general: {}
+  server: {}
   history: {}
   eventing: {}
 
@@ -948,6 +962,7 @@ aasEnvironment:
     GENERAL_DISCOVERYINTEGRATION: true
     GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.aasEnvironment }}"
   general: {}
+  server: {}
   history: {}
   eventing: {}
 
@@ -1042,6 +1057,7 @@ dppApi:
   # database. The default history settings mirror the BaSyx DPP API example.
   environment: {}
   general: {}
+  server: {}
   history:
     mode: audit
     retentionDays: 0
@@ -1134,6 +1150,7 @@ cdRepository:
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
 
@@ -1217,6 +1234,7 @@ companyLookup:
             pathType: ImplementationSpecific
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
   resources: {}
@@ -1305,6 +1323,7 @@ aasDiscovery:
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
   general: {}
+  server: {}
   history: {}
   eventing: {}
   resources: {}
@@ -1350,7 +1369,7 @@ aasWebGui:
   image:
     repository: eclipsebasyx/aas-gui
     pullPolicy: Always
-    tag: 0db02d0
+    tag: v2-260707
   imagePullSecrets: []
   nameOverride: "aas-gui"
   fullnameOverride: "aas-gui"


### PR DESCRIPTION
## Summary

This PR adds Helm chart support for the new BaSyx Go HTTP server timeout configuration variables and updates the chart defaults to BaSyx Go `1.0.2`.

## Changes

- Add structured global `server` values:
  - `server.readHeaderTimeoutSeconds`
  - `server.readTimeoutSeconds`
  - `server.writeTimeoutSeconds`
  - `server.idleTimeoutSeconds`
  - `server.shutdownTimeoutSeconds`
- Render the new values as BaSyx Go environment variables:
  - `SERVER_READ_HEADER_TIMEOUT_SECONDS`
  - `SERVER_READ_TIMEOUT_SECONDS`
  - `SERVER_WRITE_TIMEOUT_SECONDS`
  - `SERVER_IDLE_TIMEOUT_SECONDS`
  - `SERVER_SHUTDOWN_TIMEOUT_SECONDS`
- Support service-local `server` overrides for all BaSyx Go backend services.
- Document the new `server` block, default values, environment mappings, and per-service override behavior in the README.
- Add JSON schema validation for global and service-local server timeout values.
- Add Helm unittest coverage for:
  - global server timeout rendering in `basyx-common-config`
  - service-local timeout overrides
  - raw environment variable precedence
  - invalid timeout values below `1`
- Update chart defaults:
  - Chart version: `3.2.0`
  - BaSyx Go app version: `1.0.2`
  - AAS Web UI image tag: `v2-260707`
  - `curlimages/curl`: `8.21.0`
  - CloudNativePG PostgreSQL wait image: `18.4-system-trixie`
- Fix the Configuration Service database wait init container to avoid relying on shell-specific `SECONDS`; it now uses `date +%s`, which works with `/bin/sh`.

## Validation

```bash
helm lint charts/basyx -f values/values.example.yaml
helm lint charts/basyx -f values/values.secured.example.yaml
helm lint charts/basyx -f values/values.minimal.yaml
helm unittest charts/basyx
git diff --check