### PR TITLE
Add Catena-X example with external PostgreSQL and EDC UI configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'charts/**'
+      - 'values/**'
       - '!**/README.md'
       - '.github/workflows/tests.yml'
       - 'lintconf.yaml'
@@ -16,6 +17,7 @@ on:
       - main
     paths:
       - 'charts/**'
+      - 'values/**'
       - '!**/README.md'
       - '.github/workflows/tests.yml'
       - 'lintconf.yaml'

--- a/README.md
+++ b/README.md
@@ -396,11 +396,12 @@ The chart projects configured certificate sources into the pods and updates `SSL
 
 ### Database
 
-The chart creates a CloudNativePG cluster:
+By default, the chart creates a CloudNativePG cluster:
 
 ```yaml
 database:
   clusterName: basyx-database
+  type: postgres
   database: basyx
   owner: basyx
   instances: 3
@@ -417,9 +418,84 @@ database:
     size: 5Gi
 ```
 
+The values `postgres`, `managed` and `cnpg` all keep this managed database behavior for backwards compatibility.
+
+#### Existing PostgreSQL Database
+
+To use an existing PostgreSQL database instead of deploying CloudNativePG, set `database.type` to `external`.
+
+Recommended for production: point the chart to an existing Kubernetes Secret:
+
+```yaml
+database:
+  type: external
+  existingSecret: basyx-external-postgres
+```
+
+The Secret must exist in the same namespace as the BaSyx release and contain these keys:
+
+```text
+host
+port
+dbname
+user
+password
+jdbc-uri
+```
+
+Create such a Secret, for example:
+
+```bash
+kubectl -n basyx-custom create secret generic basyx-external-postgres \
+  --from-literal=host='postgres.example.internal' \
+  --from-literal=port='5432' \
+  --from-literal=dbname='basyx' \
+  --from-literal=user='basyx' \
+  --from-literal=password='change-me' \
+  --from-literal=jdbc-uri='jdbc:postgresql://postgres.example.internal:5432/basyx'
+```
+
+Then install with the external database overlay:
+
+```bash
+helm upgrade --install basyx charts/basyx \
+  -n basyx-custom \
+  --create-namespace \
+  -f values/values.example.yaml \
+  -f values/values.external-db.example.yaml
+```
+
+For quick test deployments, the connection values can also be provided inline. In that case, the chart renders a Secret automatically:
+
+```yaml
+database:
+  type: external
+  existingSecret: ""
+  external:
+    host: postgres.example.internal
+    port: "5432"
+    dbname: basyx
+    user: basyx
+    password: change-me
+```
+
+Inline values are easier to use, but less safe: the password is stored in the values file and in Helm release data. Do not commit real database passwords to Git. Use `existingSecret` for shared, production or GitOps-managed environments.
+
+For the Catena-X example, use the same overlay pattern:
+
+```bash
+helm upgrade --install basyx charts/basyx \
+  -n basyx-catena-x \
+  --create-namespace \
+  -f values/values.catena-x.example.yaml \
+  -f values/values.external-db.example.yaml
+```
+
+When `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database.
+
 ### BaSyx Configuration Service
 
-BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same CloudNativePG application secret as the runtime services.
+BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same PostgreSQL Secret as the runtime services.
 
 The Configuration Service image is versioned independently from the BaSyx runtime service images. Set `configurationService.image.tag` or, preferably for reproducible deployments, `configurationService.image.digest` explicitly when a schema migration image changes.
 
@@ -439,9 +515,9 @@ configurationService:
       - pre-upgrade
 ```
 
-`pre-upgrade` runs schema migrations before updated runtime pods are rolled out. `post-install` is used for fresh installs because the PostgreSQL cluster is created by the same chart and must exist before the job can connect.
+`pre-upgrade` runs schema migrations before updated runtime pods are rolled out. `post-install` is used for fresh installs because the PostgreSQL database must exist before the job can connect.
 
-On fresh installs, CloudNativePG may need some time before the database accepts connections. The chart therefore adds a `wait-for-database` init container that polls PostgreSQL with `pg_isready` before starting the Configuration Service. This avoids slow Kubernetes Job backoff loops when the database is simply not ready yet.
+On fresh installs, PostgreSQL may need some time before it accepts connections. The chart therefore adds a `wait-for-database` init container that polls PostgreSQL with `pg_isready` before starting the Configuration Service. This avoids slow Kubernetes Job backoff loops when the database is simply not ready yet.
 
 After deployment, verify the job and logs with:
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,23 @@ password
 jdbc-uri
 ```
 
+For BaSyx Go backend services, the Secret can additionally contain optional PostgreSQL keys:
+
+```text
+sslmode
+sslcert
+sslkey
+sslrootcert
+connectTimeoutSeconds
+applicationName
+fallbackApplicationName
+searchPath
+options
+timezone
+```
+
+These optional keys are rendered as optional `POSTGRES_*` environment variables. `searchPath` becomes `POSTGRES_SEARCHPATH` for BaSyx Go. For generated inline Secrets, it is also translated into the JDBC parameter `currentSchema` so Keycloak can use the same generated `jdbc-uri`.
+
 Create such a Secret, for example:
 
 ```bash
@@ -452,7 +469,9 @@ kubectl -n basyx-custom create secret generic basyx-external-postgres \
   --from-literal=dbname='basyx' \
   --from-literal=user='basyx' \
   --from-literal=password='change-me' \
-  --from-literal=jdbc-uri='jdbc:postgresql://postgres.example.internal:5432/basyx'
+  --from-literal=jdbc-uri='jdbc:postgresql://postgres.example.internal:5432/basyx?sslmode=require&currentSchema=myschema' \
+  --from-literal=sslmode='require' \
+  --from-literal=searchPath='myschema'
 ```
 
 Then install with the external database overlay:
@@ -477,9 +496,19 @@ database:
     dbname: basyx
     user: basyx
     password: change-me
+    sslmode: require
+    searchPath: myschema
 ```
 
 Inline values are easier to use, but less safe: the password is stored in the values file and in Helm release data. Do not commit real database passwords to Git. Use `existingSecret` for shared, production or GitOps-managed environments.
+
+When the external database is independently managed and expected to be reachable before installing the chart, the Configuration Service database wait initContainer can be disabled:
+
+```yaml
+configurationService:
+  waitForDatabase:
+    enabled: false
+```
 
 #### Service-Specific PostgreSQL Databases
 
@@ -507,7 +536,7 @@ aasRepository:
   # No override: uses the global database above.
 ```
 
-The referenced Secret must contain the same keys as the global external database Secret: `host`, `port`, `dbname`, `user`, `password` and `jdbc-uri`.
+The referenced Secret must contain the same required keys as the global external database Secret: `host`, `port`, `dbname`, `user`, `password` and `jdbc-uri`. It can also contain the optional PostgreSQL keys listed above, for example `sslmode` and `searchPath`.
 
 For quick test deployments, a service can also define the connection inline. The chart renders a service-specific Secret automatically:
 
@@ -521,6 +550,8 @@ aasRegistry:
     dbname: basyx_registry
     user: basyx_registry
     password: change-me
+    sslmode: require
+    searchPath: registry_schema
 ```
 
 Service-specific database overrides are runtime connections only. The built-in `configurationService` migrates the global database connection of the release. If a service points to a different external database, that database must already be initialized by another BaSyx release, by a separate Configuration Service run, or by an operational migration process.
@@ -535,7 +566,7 @@ helm upgrade --install basyx charts/basyx \
   -f values/values.external-db.example.yaml
 ```
 
-When global `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database.
+When global `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database. `configurationService.waitForDatabase.enabled: false` only disables the Configuration Service wait initContainer.
 
 ### BaSyx Configuration Service
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ charts/basyx/values.yaml
 Custom values files live outside the chart, for example:
 
 ```text
+values/values.catena-x.example.yaml
 values/values.example.yaml
 values/values.minimal.yaml
 values/values.secured.example.yaml
@@ -124,6 +125,9 @@ cp values/values.minimal.yaml values/values.my-minimal-environment.yaml
 
 # Secured deployment with Keycloak and ABAC.
 cp values/values.secured.example.yaml values/values.my-secured-environment.yaml
+
+# Catena-X oriented deployment with marker-based DTR and Submodel access.
+cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
 ```
 
 The unsecured example enables the core BaSyx Go services and the Web UI:
@@ -188,6 +192,8 @@ Use `values/values.minimal.yaml` when you want the BaSyx Go MinimalExample style
 
 For DPP API deployments, enable `dppApi` in your own values file. DPP commonly runs together with `aasEnvironment` and `aasWebGui`, but it is configured through the same service block pattern as the other optional BaSyx Go services.
 
+Use `values/values.catena-x.example.yaml` when you want a Catena-X oriented setup. It enables Keycloak, ABAC, Digital Twin Registry and Submodel Repository with BPN-based marker access rules.
+
 Do not publish production passwords or client secrets. For public examples, use placeholders and inject real credentials through your deployment pipeline or an external secret management solution.
 
 ## Render Before Installing
@@ -198,6 +204,7 @@ Always render the chart before the first install. This catches schema errors and
 helm lint charts/basyx -f values/values.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
+helm lint charts/basyx -f values/values.catena-x.example.yaml
 
 helm template basyx charts/basyx \
   -n basyx-custom \
@@ -285,6 +292,7 @@ With the default paths, services are exposed below one host:
 | Submodel Repository | `https://<host>/submodel-repo` or your custom override |
 | Concept Description Repository | `https://<host>/cd-repository` |
 | Company Lookup | `https://<host>/company-lookup/companies` |
+| Digital Twin Registry | `https://<host>/digital-twin-registry` |
 
 Company Lookup intentionally has no resource at the bare `/company-lookup` path. Use `/company-lookup/companies`, `/company-lookup/description`, `/company-lookup/swagger` or `/company-lookup/health`.
 
@@ -902,6 +910,7 @@ Run lint with custom values:
 helm lint charts/basyx -f values/values.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
+helm lint charts/basyx -f values/values.catena-x.example.yaml
 ```
 
 Runtime smoke tests after deployment:
@@ -953,6 +962,80 @@ Before publishing publicly:
 - Provide sanitized example values instead of production overlays.
 - Prefer fixed image tags or digests over mutable `SNAPSHOT` tags for reproducible deployments.
 - Review ABAC defaults and document deployment-specific rule sets outside the public chart when needed.
+
+## Catena-X Quick Start
+
+The Catena-X example values deploy the parts needed for marker-based Digital Twin access:
+
+- `digitalTwinRegistry` stores shell descriptors and filters them through AAS descriptor markers.
+- `submodelRepository` stores submodels and filters them through submodel and submodel-element markers.
+- `aasWebGui` is enabled with the `catena-x` infrastructure template, which uses `digitalTwinRegistry` and `submodelService` endpoints instead of the separate `Full` component set.
+- `keycloak` is enabled for a self-contained quick start and initializes demo users and token mappers.
+- `abac` is enabled globally, with service-local rules for Digital Twin Registry and Submodel Repository.
+
+Start from the example values:
+
+```bash
+cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
+```
+
+Edit at least these values before installing:
+
+```yaml
+host: basyx.example.com
+
+tls:
+  hosts:
+    - basyx.example.com
+
+keycloak:
+  secrets:
+    admin:
+      password: change-me
+    client:
+      clientPassword: change-me
+```
+
+Also replace the demo user passwords before using the file outside a throwaway test namespace.
+
+Then render and install:
+
+```bash
+helm lint charts/basyx -f values/values.my-catena-x-environment.yaml
+
+helm upgrade --install basyx charts/basyx \
+  -n basyx-catena-x \
+  --create-namespace \
+  -f values/values.my-catena-x-environment.yaml
+```
+
+The example initializes these demo users. All example passwords are `change-me`. The passwords are intentionally non-temporary in this example so the upstream Postman collection and command-line data loading examples can fetch OAuth2 password-grant tokens. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
+
+| User | Initial password | Purpose |
+| --- | --- | --- |
+| `catena-x.provider` | `change-me` | Data provider with `view_digital_twin`, `add_digital_twin`, `update_digital_twin` and `delete_digital_twin` role claims. |
+| `catena-x.partner-a` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_001` for marker-based read access tests. |
+| `catena-x.partner-b` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_002` for marker-based read access tests. |
+
+The upstream BaSyx Go marker example also contains demo data:
+
+- [shell-descriptor.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/shell-descriptor.json)
+- [public-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/public-submodel.json)
+- [restricted-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/restricted-submodel.json)
+- [BaSyx-Marker-Access.postman_collection.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json)
+
+Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment, for example with the provided Postman collection.
+
+Do not upload these files through the generic Web UI JSON/UML import. That import expects AAS or AAS Environment payloads and will reject `shell-descriptor.json` with `no AAS imported`. The marker example files must be written to their component APIs instead: `shell-descriptor.json` to Digital Twin Registry and the submodel JSON files to Submodel Repository. If you use the example data outside localhost, adjust embedded endpoint URLs in the descriptor to match your ingress host and paths.
+
+The marker rules follow the BaSyx Go marker access example:
+
+- `PUBLIC_READABLE` marks descriptors or submodels that can be read publicly.
+- Partner-specific visibility is based on the `Edc-Bpn` token claim.
+- Digital Twin Registry checks `specificAssetIds[].externalSubjectId.keys[].value` and `submodelDescriptors[].supplementalSemanticIds[].keys[].value`.
+- Submodel Repository checks `supplementalSemanticIds[].keys[].value` on submodels and submodel elements.
+
+For production Catena-X environments, prefer an external IAM or connector flow that issues a trustworthy `Edc-Bpn` token claim. Do not allow arbitrary external clients to set this claim through request headers. Header-to-claim injection should only be enabled behind a trusted ingress or connector mapping.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,50 @@ database:
 
 Inline values are easier to use, but less safe: the password is stored in the values file and in Helm release data. Do not commit real database passwords to Git. Use `existingSecret` for shared, production or GitOps-managed environments.
 
+#### Service-Specific PostgreSQL Databases
+
+The global `database` block is used by all BaSyx Go backend services by default. Individual services can override that connection when a deployment needs separate databases, for example when registries should use a shared core database while repositories use a namespace-local database.
+
+Recommended for production: reference an existing Secret on the service:
+
+```yaml
+database:
+  type: postgres
+  clusterName: basyx-company-database
+
+aasRegistry:
+  enabled: true
+  database:
+    existingSecret: basyx-core-postgres
+
+aasDiscovery:
+  enabled: true
+  database:
+    existingSecret: basyx-core-postgres
+
+aasRepository:
+  enabled: true
+  # No override: uses the global database above.
+```
+
+The referenced Secret must contain the same keys as the global external database Secret: `host`, `port`, `dbname`, `user`, `password` and `jdbc-uri`.
+
+For quick test deployments, a service can also define the connection inline. The chart renders a service-specific Secret automatically:
+
+```yaml
+aasRegistry:
+  enabled: true
+  database:
+    type: external
+    host: postgres.example.internal
+    port: "5432"
+    dbname: basyx_registry
+    user: basyx_registry
+    password: change-me
+```
+
+Service-specific database overrides are runtime connections only. The built-in `configurationService` migrates the global database connection of the release. If a service points to a different external database, that database must already be initialized by another BaSyx release, by a separate Configuration Service run, or by an operational migration process.
+
 For the Catena-X example, use the same overlay pattern:
 
 ```bash
@@ -491,7 +535,7 @@ helm upgrade --install basyx charts/basyx \
   -f values/values.external-db.example.yaml
 ```
 
-When `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database.
+When global `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database.
 
 ### BaSyx Configuration Service
 

--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,8 @@ examples/postman/basyx-catena-x-marker-access.postman_collection.json
 
 The collection contains the marker example payloads and uses the default ingress paths from `values/values.catena-x.example.yaml`.
 
+In the Web UI infrastructure configuration, `submodelService.baseUrl` points to the Submodel Repository service root, for example `https://basyx.example.com/submodel-repo`. The Web UI appends concrete API paths such as `/submodels/{submodelId}` itself.
+
 Before running it, import the collection into Postman and adjust the collection variables:
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,41 @@ The example initializes these demo users. All example passwords are `change-me`.
 | `catena-x.partner-a` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_001` for marker-based read access tests. |
 | `catena-x.partner-b` | `change-me` | Consumer with `Edc-Bpn=BPN_COMPANY_002` for marker-based read access tests. |
 
+### CatenaXplorer EDC UI Settings
+
+The Catena-X example also preconfigures the AAS Web UI with the CatenaXplorer EDC backend-for-frontend environment variables from the upstream [CatenaXplorerEdcStandalone example](https://github.com/eclipse-basyx/basyx-aas-web-ui/tree/main/examples/CatenaXplorerEdcStandalone).
+
+Non-sensitive EDC settings are stored in `aasWebGui.environment` and rendered into the Web UI ConfigMap:
+
+```yaml
+aasWebGui:
+  environment:
+    CX_EDC_BFF_ENABLED: "true"
+    CX_EDC_BFF_PORT: "3001"
+    CX_EDC_BFF_UPSTREAM_URL: "http://127.0.0.1:3001"
+    CX_EDC_BFF_AUTH_MODE: none
+    CX_EDC_DEFAULT_MANAGEMENT_URL: "https://consumer-edc.example.com/management"
+    CX_EDC_DEFAULT_API_KEY_HEADER: X-Api-Key
+    CX_EDC_DEFAULT_DSP_ENDPOINT: "https://consumer-edc.example.com/api/v1/dsp"
+    CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES: "https://provider-edc.example.com/api/v1/dsp"
+```
+
+The EDC Management API key is sensitive. Do not store a real API key in `aasWebGui.environment`. Use `aasWebGui.secretEnvironment` for disposable test overlays, or preferably reference an existing Secret in production:
+
+```yaml
+aasWebGui:
+  existingSecretEnvironment: basyx-aas-web-ui-edc
+```
+
+Create the Secret before installing:
+
+```bash
+kubectl -n basyx-catena-x create secret generic basyx-aas-web-ui-edc \
+  --from-literal=CX_EDC_DEFAULT_API_KEY='change-me'
+```
+
+If `aasWebGui.existingSecretEnvironment` is set, the chart does not render `aasWebGui.secretEnvironment`; it only references the existing Secret from the Web UI Deployment.
+
 The upstream BaSyx Go marker example also contains demo data:
 
 - [shell-descriptor.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/shell-descriptor.json)

--- a/README.md
+++ b/README.md
@@ -873,7 +873,12 @@ Raw environment maps are the escape hatch and take precedence over structured va
 | `general.externalUrl` | `GENERAL_EXTERNALURL` | Public external URL used by registry synchronization. |
 | `general.trustProxyHeaders` | `GENERAL_TRUSTPROXYHEADERS` | Trusts forwarded proxy headers. Only enable behind trusted reverse proxies. |
 | `general.trustedProxyCIDRs` | `GENERAL_TRUSTEDPROXYCIDRS` | Comma-separated trusted proxy CIDR list. |
-| `general.uploadMaxSizeBytes` | `GENERAL_UPLOADMAXSIZEBYTES` | Maximum upload size in bytes. `0` keeps the service default. |
+| `general.uploadMaxSizeBytes` | `GENERAL_UPLOADMAXSIZEBYTES` | Maximum compressed HTTP request size, including multipart overhead, in bytes. Must be greater than `0`. |
+| `general.aasxMaxPartCount` | `GENERAL_AASXMAXPARTCOUNT` | Maximum number of non-directory entries in an AASX package. |
+| `general.aasxMaxOPCMetadataSizeBytes` | `GENERAL_AASXMAXOPCMETADATASIZEBYTES` | Maximum combined expanded size of AASX OPC metadata. |
+| `general.aasxMaxPartExpandedSizeBytes` | `GENERAL_AASXMAXPARTEXPANDEDSIZEBYTES` | Maximum expanded size of one AASX payload part. |
+| `general.aasxMaxTotalExpandedSizeBytes` | `GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES` | Maximum combined expanded size of all AASX payload parts. |
+| `general.aasxMaxThumbnailSizeBytes` | `GENERAL_AASXMAXTHUMBNAILSIZEBYTES` | Maximum expanded size of an AASX thumbnail. |
 | `general.bulkBatchLimit` | `GENERAL_BULK_BATCH_LIMIT` | Maximum row count per generated bulk SQL statement. Must be greater than `0`. |
 | `general.aasPreconfigPaths` | `GENERAL_AAS_PRECONFIG_PATHS` | Comma-separated paths for preconfigured AAS input. Mount matching files or directories with service-specific `volumes` and `volumeMounts`. |
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The repository follows the common Helm multi-chart layout:
 
 ```text
 charts/basyx/           Helm chart for BaSyx Go
+examples/postman/       Postman collections for example setups
 values/                 Custom values examples and deployment overlays
 ```
 
@@ -951,6 +952,7 @@ charts/basyx/values.yaml            Default chart values
 charts/basyx/templates/             Kubernetes templates
 charts/basyx/tests/                 helm-unittest suites
 charts/basyx/config-files/          Chart-local files such as logos and optional certs
+examples/postman/                   Postman collections for example setups
 values/                             Custom values overlays
 ```
 
@@ -1009,7 +1011,7 @@ helm upgrade --install basyx charts/basyx \
   -f values/values.my-catena-x-environment.yaml
 ```
 
-The example initializes these demo users. All example passwords are `change-me`. The passwords are intentionally non-temporary in this example so the upstream Postman collection and command-line data loading examples can fetch OAuth2 password-grant tokens. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
+The example initializes these demo users. All example passwords are `change-me`. The Postman collection uses OAuth2 password-grant requests for demo data loading. Depending on your Keycloak policies, demo users may need to log in through the Web UI once and complete required account setup before those token requests succeed. Change the passwords and disable direct access grants before using this setup beyond a disposable demo namespace.
 
 | User | Initial password | Purpose |
 | --- | --- | --- |
@@ -1022,9 +1024,38 @@ The upstream BaSyx Go marker example also contains demo data:
 - [shell-descriptor.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/shell-descriptor.json)
 - [public-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/public-submodel.json)
 - [restricted-submodel.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/data/restricted-submodel.json)
-- [BaSyx-Marker-Access.postman_collection.json](https://raw.githubusercontent.com/eclipse-basyx/basyx-go-components/main/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json)
 
-Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment, for example with the provided Postman collection.
+Helm does not load those objects automatically. Download the files from the upstream example and load them explicitly after deployment.
+
+This repository also includes a generic Postman collection for the Catena-X example:
+
+```text
+examples/postman/basyx-catena-x-marker-access.postman_collection.json
+```
+
+The collection contains the marker example payloads and uses the default ingress paths from `values/values.catena-x.example.yaml`.
+
+Before running it, import the collection into Postman and adjust the collection variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `baseUrl` | `https://basyx.example.com` | Public ingress base URL without a trailing slash. |
+| `realm` | `basyx` | Keycloak realm created by the example values. |
+| `clientId` | `basyx-ui` | OAuth2 client used for password-grant token requests. |
+| `providerUsername` | `catena-x.provider` | Demo provider user. |
+| `providerPassword` | `change-me` | Demo provider password. |
+| `partnerAUsername` | `catena-x.partner-a` | Demo consumer with `Edc-Bpn=BPN_COMPANY_001`. |
+| `partnerAPassword` | `change-me` | Demo partner A password. |
+| `partnerBUsername` | `catena-x.partner-b` | Demo consumer with `Edc-Bpn=BPN_COMPANY_002`. |
+| `partnerBPassword` | `change-me` | Demo partner B password. |
+
+Run the folders in this order:
+
+1. `Auth` fetches OAuth2 access tokens for the provider and both partners.
+2. `Setup - Write Example Data` removes old test objects if present, then creates the shell descriptor and both submodels.
+3. `Read - Provider`, `Read - Partner A`, `Read - Partner B` and `Read - Anonymous` exercise the marker-based read paths with different token claims.
+
+If Postman returns `invalid_grant` with `Account is not fully set up`, the Keycloak user still has a required action such as `UPDATE_PASSWORD`, `VERIFY_EMAIL` or user profile completion. Log in with that user through the Web UI or Keycloak account console first, complete the required setup, and run the `Auth` folder again.
 
 Do not upload these files through the generic Web UI JSON/UML import. That import expects AAS or AAS Environment payloads and will reject `shell-descriptor.json` with `no AAS imported`. The marker example files must be written to their component APIs instead: `shell-descriptor.json` to Digital Twin Registry and the submodel JSON files to Submodel Repository. If you use the example data outside localhost, adjust embedded endpoint URLs in the descriptor to match your ingress host and paths.
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.3.0
-appVersion: "1.0.2"
+version: 3.3.1
+appVersion: "1.0.3"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.3.1
+version: 3.3.0
 appVersion: "1.0.3"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.2.0
+version: 3.3.0
 appVersion: "1.0.2"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -684,7 +684,24 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "database-secret" -}}
-{{- printf "%s-app" .Values.database.clusterName  | trunc 63 | trimSuffix "-" }}
+{{- if eq (include "database.managed" .) "false" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecret | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "database.generatedSecretName" . -}}
+{{- end -}}
+{{- else -}}
+{{- printf "%s-app" .Values.database.clusterName  | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end}}
+
+{{- define "database.generatedSecretName" -}}
+{{- printf "%s-external-database" (include "basyx.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end}}
+
+{{- define "database.managed" -}}
+{{- $type := .Values.database.type | default "postgres" | toString -}}
+{{- if or (eq $type "postgres") (eq $type "managed") (eq $type "cnpg") -}}true{{- else -}}false{{- end -}}
 {{- end}}
 
 {{/*
@@ -809,7 +826,7 @@ tls:
   valueFrom:
     secretKeyRef:
       name: {{ include "database-secret" . }}
-      key: port    
+      key: port
 - name: POSTGRES_HOST
   valueFrom:
     secretKeyRef:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -295,6 +295,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/common-config: {{ include "common.config.checksum" $root }}
+        checksum/database-config: {{ include "database.serviceChecksum" (dict "root" $root "component" .component "nameSuffix" .nameSuffix) }}
         {{- if eq (include "basyx.abac.enabled" $abac) "true" }}
         checksum/abac-config: {{ include "basyx.abac.checksum" $abac }}
         {{- end }}
@@ -335,7 +336,7 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           env:
-            {{- include "common-database-config" $root | nindent 12 }}
+            {{- include "common-database-config" (dict "root" $root "component" .component "nameSuffix" .nameSuffix) | nindent 12 }}
             - name: SERVER_PORT
               value: {{ $values.service.port | quote }}
             - name: SERVER_CONTEXTPATH
@@ -699,6 +700,42 @@ Create the name of the service account to use
 {{- printf "%s-external-database" (include "basyx.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end}}
 
+{{- define "database.serviceGeneratedSecretName" -}}
+{{- $root := .root -}}
+{{- $name := .nameSuffix | default .component | toString | kebabcase -}}
+{{- printf "%s-%s-database" (include "basyx.fullname" $root) $name | trunc 63 | trimSuffix "-" -}}
+{{- end}}
+
+{{- define "database.serviceSecret" -}}
+{{- $root := .root | default . -}}
+{{- $component := .component | default "" -}}
+{{- $componentValues := dict -}}
+{{- if $component -}}
+{{- $componentValues = get $root.Values $component | default dict -}}
+{{- end -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- if and $component $serviceDatabase -}}
+{{- if $serviceDatabase.existingSecret -}}
+{{- $serviceDatabase.existingSecret | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "database.serviceGeneratedSecretName" . -}}
+{{- end -}}
+{{- else -}}
+{{- include "database-secret" $root -}}
+{{- end -}}
+{{- end}}
+
+{{- define "database.serviceChecksum" -}}
+{{- $root := .root -}}
+{{- $component := .component | default "" -}}
+{{- $componentValues := dict -}}
+{{- if $component -}}
+{{- $componentValues = get $root.Values $component | default dict -}}
+{{- end -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- printf "%s\n%s\n%s\n" (include "database.serviceSecret" .) (toYaml $root.Values.database) (toYaml $serviceDatabase) | sha256sum -}}
+{{- end}}
+
 {{- define "database.managed" -}}
 {{- $type := .Values.database.type | default "postgres" | toString -}}
 {{- if or (eq $type "postgres") (eq $type "managed") (eq $type "cnpg") -}}true{{- else -}}false{{- end -}}
@@ -822,30 +859,39 @@ tls:
 {{- end }}
 
 {{- define "common-database-config" -}}
+{{- $root := . -}}
+{{- $component := "" -}}
+{{- $nameSuffix := "" -}}
+{{- if and (kindIs "map" .) (hasKey . "root") -}}
+{{- $root = .root -}}
+{{- $component = .component | default "" -}}
+{{- $nameSuffix = .nameSuffix | default "" -}}
+{{- end -}}
+{{- $secretContext := dict "root" $root "component" $component "nameSuffix" $nameSuffix -}}
 - name: POSTGRES_PORT
   valueFrom:
     secretKeyRef:
-      name: {{ include "database-secret" . }}
+      name: {{ include "database.serviceSecret" $secretContext }}
       key: port
 - name: POSTGRES_HOST
   valueFrom:
     secretKeyRef:
-      name: {{ include "database-secret" . }}
+      name: {{ include "database.serviceSecret" $secretContext }}
       key: host
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "database-secret" . }}
+      name: {{ include "database.serviceSecret" $secretContext }}
       key: password
 - name: POSTGRES_DBNAME
   valueFrom:
     secretKeyRef:
-      name: {{ include "database-secret" . }}
+      name: {{ include "database.serviceSecret" $secretContext }}
       key: dbname
 - name: POSTGRES_USER
   valueFrom:
     secretKeyRef:
-      name: {{ include "database-secret" . }}
+      name: {{ include "database.serviceSecret" $secretContext }}
       key: user
 {{- end }}
 

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -736,6 +736,15 @@ Create the name of the service account to use
 {{- printf "%s\n%s\n%s\n" (include "database.serviceSecret" .) (toYaml $root.Values.database) (toYaml $serviceDatabase) | sha256sum -}}
 {{- end}}
 
+{{- define "database.optionalEnv" -}}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secret }}
+      key: {{ .key }}
+      optional: true
+{{- end }}
+
 {{- define "database.managed" -}}
 {{- $type := .Values.database.type | default "postgres" | toString -}}
 {{- if or (eq $type "postgres") (eq $type "managed") (eq $type "cnpg") -}}true{{- else -}}false{{- end -}}
@@ -868,31 +877,42 @@ tls:
 {{- $nameSuffix = .nameSuffix | default "" -}}
 {{- end -}}
 {{- $secretContext := dict "root" $root "component" $component "nameSuffix" $nameSuffix -}}
+{{- $databaseSecret := include "database.serviceSecret" $secretContext -}}
 - name: POSTGRES_PORT
   valueFrom:
     secretKeyRef:
-      name: {{ include "database.serviceSecret" $secretContext }}
+      name: {{ $databaseSecret }}
       key: port
 - name: POSTGRES_HOST
   valueFrom:
     secretKeyRef:
-      name: {{ include "database.serviceSecret" $secretContext }}
+      name: {{ $databaseSecret }}
       key: host
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "database.serviceSecret" $secretContext }}
+      name: {{ $databaseSecret }}
       key: password
 - name: POSTGRES_DBNAME
   valueFrom:
     secretKeyRef:
-      name: {{ include "database.serviceSecret" $secretContext }}
+      name: {{ $databaseSecret }}
       key: dbname
 - name: POSTGRES_USER
   valueFrom:
     secretKeyRef:
-      name: {{ include "database.serviceSecret" $secretContext }}
+      name: {{ $databaseSecret }}
       key: user
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SSLMODE" "key" "sslmode") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SSLCERT" "key" "sslcert") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SSLKEY" "key" "sslkey") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SSLROOTCERT" "key" "sslrootcert") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_CONNECTTIMEOUTSECONDS" "key" "connectTimeoutSeconds") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_APPLICATIONNAME" "key" "applicationName") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_FALLBACKAPPLICATIONNAME" "key" "fallbackApplicationName") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SEARCHPATH" "key" "searchPath") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_OPTIONS" "key" "options") }}
+{{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_TIMEZONE" "key" "timezone") }}
 {{- end }}
 
 {{- define "basyx.abac.enabled" -}}

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -102,11 +102,23 @@ Render an image reference, preferring digest over tag when provided.
 {{- end }}
 
 {{/*
+Render scalar config values. Large numeric YAML values may arrive as float64;
+format them without scientific notation so environment variables stay valid.
+*/}}
+{{- define "basyx.configValue" -}}
+{{- if kindIs "float64" .value -}}
+{{- printf "%.0f" .value -}}
+{{- else -}}
+{{- tpl (print .value) .root -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render a common config entry unless the raw environment map explicitly overrides it.
 */}}
 {{- define "basyx.commonConfig.entry" -}}
 {{- if not (hasKey .common .name) }}
-{{ .name }}: {{ tpl (print .value) .root | quote }}
+{{ .name }}: {{ include "basyx.configValue" (dict "root" .root "value" .value) | quote }}
 {{- end }}
 {{- end }}
 
@@ -127,7 +139,7 @@ and takes precedence.
 {{- define "basyx.serviceRuntimeEnv.entry" -}}
 {{- if and (hasKey .config .key) (not (hasKey .environment .name)) }}
 - name: {{ .name }}
-  value: {{ tpl (print (get .config .key)) .root | quote }}
+  value: {{ include "basyx.configValue" (dict "root" .root "value" (get .config .key)) | quote }}
 {{- end }}
 {{- end }}
 
@@ -166,7 +178,12 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_EXTERNALURL" "value" (dig "externalUrl" "" $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_TRUSTPROXYHEADERS" "value" (dig "trustProxyHeaders" false $general)) }}
 {{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "GENERAL_TRUSTEDPROXYCIDRS" "value" (dig "trustedProxyCIDRs" (list) $general)) }}
-{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_UPLOADMAXSIZEBYTES" "value" (dig "uploadMaxSizeBytes" 0 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_UPLOADMAXSIZEBYTES" "value" (dig "uploadMaxSizeBytes" 134217728 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASXMAXPARTCOUNT" "value" (dig "aasxMaxPartCount" 10000 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASXMAXOPCMETADATASIZEBYTES" "value" (dig "aasxMaxOPCMetadataSizeBytes" 16777216 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASXMAXPARTEXPANDEDSIZEBYTES" "value" (dig "aasxMaxPartExpandedSizeBytes" 134217728 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES" "value" (dig "aasxMaxTotalExpandedSizeBytes" 134217728 $general)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_AASXMAXTHUMBNAILSIZEBYTES" "value" (dig "aasxMaxThumbnailSizeBytes" 16777216 $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_BULK_BATCH_LIMIT" "value" (dig "bulkBatchLimit" 1000 $general)) }}
 {{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "GENERAL_AAS_PRECONFIG_PATHS" "value" (dig "aasPreconfigPaths" (list) $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "SERVER_READ_HEADER_TIMEOUT_SECONDS" "value" (dig "readHeaderTimeoutSeconds" 15 $server)) }}
@@ -232,6 +249,11 @@ Render service-local BaSyx runtime overrides as explicit container env values.
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "trustProxyHeaders" "name" "GENERAL_TRUSTPROXYHEADERS") }}
 {{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $general "key" "trustedProxyCIDRs" "name" "GENERAL_TRUSTEDPROXYCIDRS") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "uploadMaxSizeBytes" "name" "GENERAL_UPLOADMAXSIZEBYTES") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasxMaxPartCount" "name" "GENERAL_AASXMAXPARTCOUNT") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasxMaxOPCMetadataSizeBytes" "name" "GENERAL_AASXMAXOPCMETADATASIZEBYTES") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasxMaxPartExpandedSizeBytes" "name" "GENERAL_AASXMAXPARTEXPANDEDSIZEBYTES") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasxMaxTotalExpandedSizeBytes" "name" "GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES") }}
+{{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "aasxMaxThumbnailSizeBytes" "name" "GENERAL_AASXMAXTHUMBNAILSIZEBYTES") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $general "key" "bulkBatchLimit" "name" "GENERAL_BULK_BATCH_LIMIT") }}
 {{- include "basyx.serviceRuntimeEnv.listEntry" (dict "environment" $environment "config" $general "key" "aasPreconfigPaths" "name" "GENERAL_AAS_PRECONFIG_PATHS") }}
 {{- include "basyx.serviceRuntimeEnv.entry" (dict "root" $root "environment" $environment "config" $server "key" "readHeaderTimeoutSeconds" "name" "SERVER_READ_HEADER_TIMEOUT_SECONDS") }}

--- a/charts/basyx/templates/aas-web-gui/deployment.yaml
+++ b/charts/basyx/templates/aas-web-gui/deployment.yaml
@@ -12,8 +12,15 @@ spec:
       {{- include "basyx-aasWebGui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.aasWebGui.podAnnotations }}
       annotations:
+        checksum/aas-web-gui-config: {{ include (print $.Template.BasePath "/aas-web-gui/configmap.yaml") . | sha256sum }}
+        {{- if .Values.aasWebGui.infrastructureConfig }}
+        checksum/aas-web-gui-infrastructure: {{ include (print $.Template.BasePath "/aas-web-gui/configmap-infrastructure.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.aasWebGui.logos }}
+        checksum/aas-web-gui-logos: {{ include (print $.Template.BasePath "/aas-web-gui/configmap-logos.yaml") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.aasWebGui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/basyx/templates/aas-web-gui/deployment.yaml
+++ b/charts/basyx/templates/aas-web-gui/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         checksum/aas-web-gui-config: {{ include (print $.Template.BasePath "/aas-web-gui/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.aasWebGui.secretEnvironment (not .Values.aasWebGui.existingSecretEnvironment) }}
+        checksum/aas-web-gui-secret: {{ include (print $.Template.BasePath "/aas-web-gui/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.aasWebGui.infrastructureConfig }}
         checksum/aas-web-gui-infrastructure: {{ include (print $.Template.BasePath "/aas-web-gui/configmap-infrastructure.yaml") . | sha256sum }}
         {{- end }}
@@ -62,6 +65,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "basyx-aasWebGui.fullname" . }}-config
+            {{- if or .Values.aasWebGui.secretEnvironment .Values.aasWebGui.existingSecretEnvironment }}
+            - secretRef:
+                name: {{ default (printf "%s-secret" (include "basyx-aasWebGui.fullname" .)) .Values.aasWebGui.existingSecretEnvironment }}
+            {{- end }}
           resources:
             {{- toYaml .Values.aasWebGui.resources | nindent 12 }}
           {{- with .Values.aasWebGui.livenessProbe }}

--- a/charts/basyx/templates/aas-web-gui/secret.yaml
+++ b/charts/basyx/templates/aas-web-gui/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.aasWebGui.enabled .Values.aasWebGui.secretEnvironment (not .Values.aasWebGui.existingSecretEnvironment) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "basyx-aasWebGui.fullname" . }}-secret
+  labels:
+    {{- include "basyx-aasWebGui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.aasWebGui.secretEnvironment }}
+  {{ $key }}: {{ tpl (print $value) $ | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/basyx/templates/database-secret.yaml
+++ b/charts/basyx/templates/database-secret.yaml
@@ -20,3 +20,44 @@ stringData:
   password: {{ $password | toString | quote }}
   jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) | quote }}
 {{- end }}
+{{- $root := . -}}
+{{- $components := list
+  (dict "component" "aasDiscovery" "nameSuffix" "aas-discovery")
+  (dict "component" "aasRegistry" "nameSuffix" "aas-registry")
+  (dict "component" "aasRepository" "nameSuffix" "aas-repository")
+  (dict "component" "aasEnvironment" "nameSuffix" "aas-environment")
+  (dict "component" "dppApi" "nameSuffix" "dpp-api")
+  (dict "component" "submodelRegistry" "nameSuffix" "submodel-registry")
+  (dict "component" "submodelRepository" "nameSuffix" "submodel-repository")
+  (dict "component" "cdRepository" "nameSuffix" "cd-repository")
+  (dict "component" "companyLookup" "nameSuffix" "company-lookup")
+  (dict "component" "digitalTwinRegistry" "nameSuffix" "digital-twin-registry")
+-}}
+{{- range $service := $components }}
+{{- $values := get $root.Values $service.component | default dict -}}
+{{- $serviceDatabase := get $values "database" | default dict -}}
+{{- if and $values.enabled $serviceDatabase (not $serviceDatabase.existingSecret) }}
+{{- $external := get $serviceDatabase "external" | default dict -}}
+{{- $host := required (printf "%s.database.host or %s.database.external.host is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "host") (get $serviceDatabase "host")) -}}
+{{- $port := required (printf "%s.database.port or %s.database.external.port is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "port") (get $serviceDatabase "port")) -}}
+{{- $dbname := required (printf "%s.database.dbname or %s.database.external.dbname is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "dbname") (get $serviceDatabase "dbname")) -}}
+{{- $user := required (printf "%s.database.user or %s.database.external.user is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "user") (get $serviceDatabase "user")) -}}
+{{- $password := required (printf "%s.database.password or %s.database.external.password is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "password") (get $serviceDatabase "password")) -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "database.serviceGeneratedSecretName" (dict "root" $root "component" $service.component "nameSuffix" $service.nameSuffix) }}
+  labels:
+    {{- include "basyx.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $service.nameSuffix | quote }}
+type: Opaque
+stringData:
+  host: {{ $host | toString | quote }}
+  port: {{ $port | toString | quote }}
+  dbname: {{ $dbname | toString | quote }}
+  user: {{ $user | toString | quote }}
+  password: {{ $password | toString | quote }}
+  jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) | quote }}
+{{- end }}
+{{- end }}

--- a/charts/basyx/templates/database-secret.yaml
+++ b/charts/basyx/templates/database-secret.yaml
@@ -5,6 +5,17 @@
 {{- $dbname := required "database.external.dbname is required when database.type is external and database.existingSecret is empty" $external.dbname -}}
 {{- $user := required "database.external.user is required when database.type is external and database.existingSecret is empty" $external.user -}}
 {{- $password := required "database.external.password is required when database.type is external and database.existingSecret is empty" $external.password -}}
+{{- $jdbcParams := list -}}
+{{- with (get $external "sslmode") }}{{- $jdbcParams = append $jdbcParams (printf "sslmode=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "sslcert") }}{{- $jdbcParams = append $jdbcParams (printf "sslcert=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "sslkey") }}{{- $jdbcParams = append $jdbcParams (printf "sslkey=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "sslrootcert") }}{{- $jdbcParams = append $jdbcParams (printf "sslrootcert=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "connectTimeoutSeconds") }}{{- $jdbcParams = append $jdbcParams (printf "connectTimeout=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "applicationName") }}{{- $jdbcParams = append $jdbcParams (printf "ApplicationName=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "searchPath") }}{{- $jdbcParams = append $jdbcParams (printf "currentSchema=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with (get $external "options") }}{{- $jdbcParams = append $jdbcParams (printf "options=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- $jdbcUri := printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) -}}
+{{- if $jdbcParams }}{{- $jdbcUri = printf "%s?%s" $jdbcUri (join "&" $jdbcParams) -}}{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,7 +29,37 @@ stringData:
   dbname: {{ $dbname | toString | quote }}
   user: {{ $user | toString | quote }}
   password: {{ $password | toString | quote }}
-  jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) | quote }}
+  jdbc-uri: {{ $jdbcUri | quote }}
+  {{- with (get $external "sslmode") }}
+  sslmode: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "sslcert") }}
+  sslcert: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "sslkey") }}
+  sslkey: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "sslrootcert") }}
+  sslrootcert: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "connectTimeoutSeconds") }}
+  connectTimeoutSeconds: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "applicationName") }}
+  applicationName: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "fallbackApplicationName") }}
+  fallbackApplicationName: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "searchPath") }}
+  searchPath: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "options") }}
+  options: {{ . | toString | quote }}
+  {{- end }}
+  {{- with (get $external "timezone") }}
+  timezone: {{ . | toString | quote }}
+  {{- end }}
 {{- end }}
 {{- $root := . -}}
 {{- $components := list
@@ -43,6 +84,27 @@ stringData:
 {{- $dbname := required (printf "%s.database.dbname or %s.database.external.dbname is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "dbname") (get $serviceDatabase "dbname")) -}}
 {{- $user := required (printf "%s.database.user or %s.database.external.user is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "user") (get $serviceDatabase "user")) -}}
 {{- $password := required (printf "%s.database.password or %s.database.external.password is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "password") (get $serviceDatabase "password")) -}}
+{{- $sslmode := default (get $external "sslmode") (get $serviceDatabase "sslmode") -}}
+{{- $sslcert := default (get $external "sslcert") (get $serviceDatabase "sslcert") -}}
+{{- $sslkey := default (get $external "sslkey") (get $serviceDatabase "sslkey") -}}
+{{- $sslrootcert := default (get $external "sslrootcert") (get $serviceDatabase "sslrootcert") -}}
+{{- $connectTimeoutSeconds := default (get $external "connectTimeoutSeconds") (get $serviceDatabase "connectTimeoutSeconds") -}}
+{{- $applicationName := default (get $external "applicationName") (get $serviceDatabase "applicationName") -}}
+{{- $fallbackApplicationName := default (get $external "fallbackApplicationName") (get $serviceDatabase "fallbackApplicationName") -}}
+{{- $searchPath := default (get $external "searchPath") (get $serviceDatabase "searchPath") -}}
+{{- $options := default (get $external "options") (get $serviceDatabase "options") -}}
+{{- $timezone := default (get $external "timezone") (get $serviceDatabase "timezone") -}}
+{{- $jdbcParams := list -}}
+{{- with $sslmode }}{{- $jdbcParams = append $jdbcParams (printf "sslmode=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $sslcert }}{{- $jdbcParams = append $jdbcParams (printf "sslcert=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $sslkey }}{{- $jdbcParams = append $jdbcParams (printf "sslkey=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $sslrootcert }}{{- $jdbcParams = append $jdbcParams (printf "sslrootcert=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $connectTimeoutSeconds }}{{- $jdbcParams = append $jdbcParams (printf "connectTimeout=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $applicationName }}{{- $jdbcParams = append $jdbcParams (printf "ApplicationName=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $searchPath }}{{- $jdbcParams = append $jdbcParams (printf "currentSchema=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- with $options }}{{- $jdbcParams = append $jdbcParams (printf "options=%s" (. | toString | urlquery)) -}}{{- end -}}
+{{- $jdbcUri := printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) -}}
+{{- if $jdbcParams }}{{- $jdbcUri = printf "%s?%s" $jdbcUri (join "&" $jdbcParams) -}}{{- end -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -58,6 +120,36 @@ stringData:
   dbname: {{ $dbname | toString | quote }}
   user: {{ $user | toString | quote }}
   password: {{ $password | toString | quote }}
-  jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) | quote }}
+  jdbc-uri: {{ $jdbcUri | quote }}
+  {{- with $sslmode }}
+  sslmode: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $sslcert }}
+  sslcert: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $sslkey }}
+  sslkey: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $sslrootcert }}
+  sslrootcert: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $connectTimeoutSeconds }}
+  connectTimeoutSeconds: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $applicationName }}
+  applicationName: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $fallbackApplicationName }}
+  fallbackApplicationName: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $searchPath }}
+  searchPath: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $options }}
+  options: {{ . | toString | quote }}
+  {{- end }}
+  {{- with $timezone }}
+  timezone: {{ . | toString | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/basyx/templates/database-secret.yaml
+++ b/charts/basyx/templates/database-secret.yaml
@@ -1,0 +1,22 @@
+{{- if and (eq (include "database.managed" .) "false") (not .Values.database.existingSecret) -}}
+{{- $external := .Values.database.external | default dict -}}
+{{- $host := required "database.external.host is required when database.type is external and database.existingSecret is empty" $external.host -}}
+{{- $port := required "database.external.port is required when database.type is external and database.existingSecret is empty" $external.port -}}
+{{- $dbname := required "database.external.dbname is required when database.type is external and database.existingSecret is empty" $external.dbname -}}
+{{- $user := required "database.external.user is required when database.type is external and database.existingSecret is empty" $external.user -}}
+{{- $password := required "database.external.password is required when database.type is external and database.existingSecret is empty" $external.password -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "database.generatedSecretName" . }}
+  labels:
+    {{- include "basyx.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  host: {{ $host | toString | quote }}
+  port: {{ $port | toString | quote }}
+  dbname: {{ $dbname | toString | quote }}
+  user: {{ $user | toString | quote }}
+  password: {{ $password | toString | quote }}
+  jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s" ($host | toString) ($port | toString) ($dbname | toString) | quote }}
+{{- end }}

--- a/charts/basyx/templates/keycloak/deployment.yaml
+++ b/charts/basyx/templates/keycloak/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: KC_HOSTNAME
               value: {{ .Values.host  | quote }}
             - name: KC_DB
-              value: {{ .Values.database.type  | quote }}
+              value: "postgres"
             - name: KC_DB_URL
               valueFrom:
                 secretKeyRef:

--- a/charts/basyx/templates/postgres.yaml
+++ b/charts/basyx/templates/postgres.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "database.managed" .) "true" -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -14,4 +15,4 @@ spec:
       database: {{.Values.database.database | default "basyx" }}
       owner: {{.Values.database.owner | default "basyx" }}
 
- 
+{{- end }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -18,6 +18,7 @@ The suites cover stable chart contracts such as:
 - ABAC mounts and rollout checksum annotations in backend deployments
 - optional AAS Environment deployment, ingress and ABAC wiring
 - optional DPP API deployment, ingress and ABAC wiring
+- Catena-X example values and marker-based ABAC wiring
 - common OIDC and ingress configuration
 - additional custom CA certificate mounts and trust-store wiring
 - runtime `helm test` hook for custom CA mount checks

--- a/charts/basyx/tests/abac_config_test.yaml
+++ b/charts/basyx/tests/abac_config_test.yaml
@@ -132,3 +132,50 @@ tests:
       - matchRegex:
           path: data["trustlist.json"]
           pattern: '"audience": "discovery-service"'
+
+  - it: renders Catena-X Digital Twin Registry ABAC rules from example values
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-digital-twin-registry-abac-config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"CLAIM": "Edc-Bpn"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"PUBLIC_READABLE"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '\$aasdesc#submodelDescriptors\[\]\.supplementalSemanticIds\[\]\.keys\[\]\.value'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/digital-twin-registry/lookup/shells"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"USEOBJECTS": \["all_shell_descriptors"\]'
+
+  - it: renders Catena-X Submodel Repository ABAC rules from example values
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-submodel-repository-abac-config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"CLAIM": "Edc-Bpn"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"PUBLIC_READABLE"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '\$sme#supplementalSemanticIds\[\]\.keys\[\]\.value'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/submodel-repo/query/submodels"'

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -74,6 +74,8 @@ tests:
       aasRepository.history.evidence.enabled: true
       aasRepository.eventing.topicPrefix: aas-repository-events
       aasRepository.general.aasPreconfigPaths[0]: /aas/preconfigured
+      aasRepository.general.aasxMaxPartCount: 12000
+      aasRepository.general.aasxMaxTotalExpandedSizeBytes: 268435456
       aasRepository.general.bulkBatchLimit: 250
       aasRepository.server.readTimeoutSeconds: 120
       aasRepository.server.shutdownTimeoutSeconds: 20
@@ -104,6 +106,18 @@ tests:
           content:
             name: GENERAL_AAS_PRECONFIG_PATHS
             value: /aas/preconfigured
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERAL_AASXMAXPARTCOUNT
+            value: "12000"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES
+            value: "268435456"
           count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -150,6 +164,8 @@ tests:
       aasRepository.environment.BASYX_HISTORY_MODE: audit
       aasRepository.general.bulkBatchLimit: 250
       aasRepository.environment.GENERAL_BULK_BATCH_LIMIT: 100
+      aasRepository.general.aasxMaxPartCount: 12000
+      aasRepository.environment.GENERAL_AASXMAXPARTCOUNT: 11000
       aasRepository.server.readTimeoutSeconds: 120
       aasRepository.environment.SERVER_READ_TIMEOUT_SECONDS: 90
       aasRepository.abac.policyScope: structured-scope
@@ -166,6 +182,12 @@ tests:
           content:
             name: GENERAL_BULK_BATCH_LIMIT
             value: "100"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERAL_AASXMAXPARTCOUNT
+            value: "11000"
           count: 1
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -3,6 +3,7 @@ release:
   name: basyx
 templates:
   - templates/secret.yaml
+  - templates/aas-web-gui/configmap.yaml
   - templates/aas-web-gui/configmap-infrastructure.yaml
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
@@ -195,6 +196,54 @@ tests:
       - matchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'baseUrl: https://basyx\.example\.com/aas-repository'
+
+  - it: renders Catena-X web ui infrastructure from example values
+    template: templates/aas-web-gui/configmap-infrastructure.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-aas-web-ui-infrastructure
+    asserts:
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'default: catena-x'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'template: catena-x'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'digitalTwinRegistry:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'baseUrl: https://basyx\.example\.com/digital-twin-registry'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'submodelService:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+      - notMatchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'aasRepository:'
+      - notMatchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'conceptDescriptionRepository:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'type: oauth2'
+
+  - it: renders Catena-X web ui runtime settings from example values
+    template: templates/aas-web-gui/configmap.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-aas-web-ui-config
+    asserts:
+      - equal:
+          path: data.START_PAGE_ROUTE_NAME
+          value: CatenaXplorer
 
   - it: mounts common config and custom ca into aas discovery
     template: templates/aas-discovery/deployment.yaml

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -271,7 +271,13 @@ tests:
           pattern: 'submodelService:'
       - matchRegex:
           path: data["basyx-infra.yml"]
-          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo'
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'companyLookup:'
+      - matchRegex:
+          path: data["basyx-infra.yml"]
+          pattern: 'baseUrl: https://basyx\.example\.com/company-lookup'
       - notMatchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'aasRepository:'

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -46,6 +46,24 @@ tests:
       - equal:
           path: stringData.SERVER_SHUTDOWN_TIMEOUT_SECONDS
           value: "10"
+      - equal:
+          path: stringData.GENERAL_UPLOADMAXSIZEBYTES
+          value: "134217728"
+      - equal:
+          path: stringData.GENERAL_AASXMAXPARTCOUNT
+          value: "10000"
+      - equal:
+          path: stringData.GENERAL_AASXMAXOPCMETADATASIZEBYTES
+          value: "16777216"
+      - equal:
+          path: stringData.GENERAL_AASXMAXPARTEXPANDEDSIZEBYTES
+          value: "134217728"
+      - equal:
+          path: stringData.GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES
+          value: "134217728"
+      - equal:
+          path: stringData.GENERAL_AASXMAXTHUMBNAILSIZEBYTES
+          value: "16777216"
 
   - it: renders structured BaSyx runtime configuration into the common secret
     template: templates/secret.yaml
@@ -55,6 +73,12 @@ tests:
     set:
       aasDiscovery.enabled: true
       general.trustProxyHeaders: true
+      general.uploadMaxSizeBytes: 268435456
+      general.aasxMaxPartCount: 20000
+      general.aasxMaxOPCMetadataSizeBytes: 33554432
+      general.aasxMaxPartExpandedSizeBytes: 268435456
+      general.aasxMaxTotalExpandedSizeBytes: 536870912
+      general.aasxMaxThumbnailSizeBytes: 8388608
       general.bulkBatchLimit: 500
       general.aasPreconfigPaths[0]: /app/preconfiguration
       server.readHeaderTimeoutSeconds: 20
@@ -85,6 +109,24 @@ tests:
       - equal:
           path: stringData.GENERAL_AAS_PRECONFIG_PATHS
           value: /app/preconfiguration
+      - equal:
+          path: stringData.GENERAL_UPLOADMAXSIZEBYTES
+          value: "268435456"
+      - equal:
+          path: stringData.GENERAL_AASXMAXPARTCOUNT
+          value: "20000"
+      - equal:
+          path: stringData.GENERAL_AASXMAXOPCMETADATASIZEBYTES
+          value: "33554432"
+      - equal:
+          path: stringData.GENERAL_AASXMAXPARTEXPANDEDSIZEBYTES
+          value: "268435456"
+      - equal:
+          path: stringData.GENERAL_AASXMAXTOTALEXPANDEDSIZEBYTES
+          value: "536870912"
+      - equal:
+          path: stringData.GENERAL_AASXMAXTHUMBNAILSIZEBYTES
+          value: "8388608"
       - equal:
           path: stringData.GENERAL_BULK_BATCH_LIMIT
           value: "500"
@@ -163,6 +205,8 @@ tests:
       environment.common.BASYX_HISTORY_MODE: api
       general.bulkBatchLimit: 500
       environment.common.GENERAL_BULK_BATCH_LIMIT: 250
+      general.aasxMaxPartCount: 20000
+      environment.common.GENERAL_AASXMAXPARTCOUNT: 15000
       server.readTimeoutSeconds: 600
       environment.common.SERVER_READ_TIMEOUT_SECONDS: 120
       abac.policyScope: structured-scope
@@ -174,6 +218,9 @@ tests:
       - equal:
           path: stringData.GENERAL_BULK_BATCH_LIMIT
           value: "250"
+      - equal:
+          path: stringData.GENERAL_AASXMAXPARTCOUNT
+          value: "15000"
       - equal:
           path: stringData.SERVER_READ_TIMEOUT_SECONDS
           value: "120"

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -6,6 +6,7 @@ templates:
   - templates/aas-web-gui/configmap.yaml
   - templates/aas-web-gui/configmap-infrastructure.yaml
   - templates/aas-web-gui/configmap-logos.yaml
+  - templates/aas-web-gui/secret.yaml
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
   - templates/aas-discovery/ingress.yaml
@@ -245,6 +246,56 @@ tests:
       - equal:
           path: data.START_PAGE_ROUTE_NAME
           value: CatenaXplorer
+      - equal:
+          path: data.CX_EDC_BFF_ENABLED
+          value: "true"
+      - equal:
+          path: data.CX_EDC_BFF_PORT
+          value: "3001"
+      - equal:
+          path: data.CX_EDC_BFF_UPSTREAM_URL
+          value: http://127.0.0.1:3001
+      - equal:
+          path: data.CX_EDC_BFF_AUTH_MODE
+          value: none
+      - equal:
+          path: data.CX_EDC_DEFAULT_MANAGEMENT_URL
+          value: https://consumer-edc.example.com/management
+      - equal:
+          path: data.CX_EDC_DEFAULT_API_KEY_HEADER
+          value: X-Api-Key
+      - equal:
+          path: data.CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES
+          value: https://provider-edc.example.com/api/v1/dsp
+      - equal:
+          path: data.CX_EDC_EDR_POLLING_ATTEMPTS
+          value: "60"
+
+  - it: renders Catena-X web ui secret runtime settings from example values
+    template: templates/aas-web-gui/secret.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-aas-web-ui-secret
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.CX_EDC_DEFAULT_API_KEY
+          value: ""
+
+  - it: wires Catena-X web ui secret runtime settings into the deployment
+    template: templates/aas-web-gui/deployment.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: basyx-aas-web-ui-secret
+          count: 1
 
   - it: mounts common config and custom ca into aas discovery
     template: templates/aas-discovery/deployment.yaml

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -5,6 +5,7 @@ templates:
   - templates/secret.yaml
   - templates/aas-web-gui/configmap.yaml
   - templates/aas-web-gui/configmap-infrastructure.yaml
+  - templates/aas-web-gui/configmap-logos.yaml
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
   - templates/aas-discovery/ingress.yaml
@@ -222,7 +223,7 @@ tests:
           pattern: 'submodelService:'
       - matchRegex:
           path: data["basyx-infra.yml"]
-          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo'
       - notMatchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'aasRepository:'
@@ -317,6 +318,12 @@ tests:
     set:
       aasWebGui.enabled: true
     asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-config"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-infrastructure"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/aas-web-gui-logos"]
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /aas-gui/

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -271,7 +271,7 @@ tests:
           pattern: 'submodelService:'
       - matchRegex:
           path: data["basyx-infra.yml"]
-          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo/submodels'
+          pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo'
       - matchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'companyLookup:'

--- a/charts/basyx/tests/database_test.yaml
+++ b/charts/basyx/tests/database_test.yaml
@@ -64,6 +64,29 @@ tests:
           path: stringData.jdbc-uri
           value: jdbc:postgresql://postgres.example.internal:5432/basyx
 
+  - it: renders optional external database parameters
+    template: templates/database-secret.yaml
+    set:
+      database.type: external
+      database.existingSecret: ""
+      database.external.host: postgres.example.internal
+      database.external.port: "5432"
+      database.external.dbname: basyx
+      database.external.user: basyx
+      database.external.password: change-me
+      database.external.sslmode: require
+      database.external.searchPath: myschema
+    asserts:
+      - equal:
+          path: stringData.sslmode
+          value: require
+      - equal:
+          path: stringData.searchPath
+          value: myschema
+      - equal:
+          path: stringData.jdbc-uri
+          value: jdbc:postgresql://postgres.example.internal:5432/basyx?sslmode=require&currentSchema=myschema
+
   - it: renders an external database jdbc uri when port is numeric
     template: templates/database-secret.yaml
     set:
@@ -177,6 +200,26 @@ tests:
                 name: basyx-external-postgres
                 key: user
           count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_SSLMODE
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: sslmode
+                optional: true
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_SEARCHPATH
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: searchPath
+                optional: true
+          count: 1
 
   - it: lets a backend service use its own existing database secret
     template: templates/aas-registry/deployment.yaml
@@ -214,6 +257,8 @@ tests:
       aasRegistry.database.dbname: aas_registry
       aasRegistry.database.user: aas_registry
       aasRegistry.database.password: change-me
+      aasRegistry.database.sslmode: require
+      aasRegistry.database.searchPath: registry_schema
     asserts:
       - hasDocuments:
           count: 1
@@ -229,8 +274,14 @@ tests:
           path: stringData.dbname
           value: aas_registry
       - equal:
+          path: stringData.sslmode
+          value: require
+      - equal:
+          path: stringData.searchPath
+          value: registry_schema
+      - equal:
           path: stringData.jdbc-uri
-          value: jdbc:postgresql://aas-registry-postgres.example.internal:5432/aas_registry
+          value: jdbc:postgresql://aas-registry-postgres.example.internal:5432/aas_registry?sslmode=require&currentSchema=registry_schema
 
   - it: wires an inline service-specific database secret into a backend service
     template: templates/aas-registry/deployment.yaml
@@ -260,6 +311,16 @@ tests:
               secretKeyRef:
                 name: basyx-aas-registry-database
                 key: user
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_SEARCHPATH
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-database
+                key: searchPath
+                optional: true
           count: 1
 
   - it: wires generated inline external database secret into keycloak

--- a/charts/basyx/tests/database_test.yaml
+++ b/charts/basyx/tests/database_test.yaml
@@ -1,0 +1,207 @@
+suite: database configuration
+release:
+  name: basyx
+templates:
+  - templates/postgres.yaml
+  - templates/database-secret.yaml
+  - templates/configuration-service-job.yaml
+  - templates/aas-registry/deployment.yaml
+  - templates/keycloak/deployment.yaml
+tests:
+  - it: renders a managed CloudNativePG cluster by default
+    template: templates/postgres.yaml
+    asserts:
+      - isKind:
+          of: Cluster
+      - equal:
+          path: apiVersion
+          value: postgresql.cnpg.io/v1
+      - equal:
+          path: metadata.name
+          value: basyx-database
+
+  - it: does not render CloudNativePG when an external database is configured
+    template: templates/postgres.yaml
+    set:
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an external database secret from inline values
+    template: templates/database-secret.yaml
+    set:
+      database.type: external
+      database.existingSecret: ""
+      database.external.host: postgres.example.internal
+      database.external.port: "5432"
+      database.external.dbname: basyx
+      database.external.user: basyx
+      database.external.password: change-me
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: basyx-external-database
+      - equal:
+          path: stringData.host
+          value: postgres.example.internal
+      - equal:
+          path: stringData.port
+          value: "5432"
+      - equal:
+          path: stringData.dbname
+          value: basyx
+      - equal:
+          path: stringData.user
+          value: basyx
+      - equal:
+          path: stringData.password
+          value: change-me
+      - equal:
+          path: stringData.jdbc-uri
+          value: jdbc:postgresql://postgres.example.internal:5432/basyx
+
+  - it: renders an external database jdbc uri when port is numeric
+    template: templates/database-secret.yaml
+    set:
+      database.type: external
+      database.existingSecret: ""
+      database.external.host: postgres.example.internal
+      database.external.port: 5432
+      database.external.dbname: basyx
+      database.external.user: basyx
+      database.external.password: change-me
+    asserts:
+      - equal:
+          path: stringData.port
+          value: "5432"
+      - equal:
+          path: stringData.jdbc-uri
+          value: jdbc:postgresql://postgres.example.internal:5432/basyx
+
+  - it: does not render an external database secret when existingSecret is configured
+    template: templates/database-secret.yaml
+    set:
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: wires external database credentials into the configuration service
+    template: templates/configuration-service-job.yaml
+    set:
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: password
+          count: 1
+
+  - it: wires generated inline external database secret into the configuration service
+    template: templates/configuration-service-job.yaml
+    set:
+      database.type: external
+      database.existingSecret: ""
+      database.external.host: postgres.example.internal
+      database.external.port: "5432"
+      database.external.dbname: basyx
+      database.external.user: basyx
+      database.external.password: change-me
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-database
+                key: host
+          count: 1
+
+  - it: ignores existingSecret for managed database mode
+    template: templates/configuration-service-job.yaml
+    set:
+      database.existingSecret: should-not-be-used
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: host
+          count: 1
+
+  - it: wires external database credentials into backend services
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DBNAME
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: dbname
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-postgres
+                key: user
+          count: 1
+
+  - it: wires generated inline external database secret into keycloak
+    template: templates/keycloak/deployment.yaml
+    set:
+      keycloak.enabled: true
+      database.type: external
+      database.existingSecret: ""
+      database.external.host: postgres.example.internal
+      database.external.port: "5432"
+      database.external.dbname: basyx
+      database.external.user: basyx
+      database.external.password: change-me
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DB
+            value: "postgres"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DB_URL
+            valueFrom:
+              secretKeyRef:
+                name: basyx-external-database
+                key: jdbc-uri
+          count: 1

--- a/charts/basyx/tests/database_test.yaml
+++ b/charts/basyx/tests/database_test.yaml
@@ -178,6 +178,90 @@ tests:
                 key: user
           count: 1
 
+  - it: lets a backend service use its own existing database secret
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-global-postgres
+      aasRegistry.database.existingSecret: basyx-aas-registry-postgres
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-postgres
+                key: host
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-global-postgres
+                key: host
+
+  - it: renders an inline service-specific database secret
+    template: templates/database-secret.yaml
+    set:
+      aasRegistry.enabled: true
+      aasRegistry.database.type: external
+      aasRegistry.database.host: aas-registry-postgres.example.internal
+      aasRegistry.database.port: "5432"
+      aasRegistry.database.dbname: aas_registry
+      aasRegistry.database.user: aas_registry
+      aasRegistry.database.password: change-me
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: basyx-aas-registry-database
+      - equal:
+          path: stringData.host
+          value: aas-registry-postgres.example.internal
+      - equal:
+          path: stringData.dbname
+          value: aas_registry
+      - equal:
+          path: stringData.jdbc-uri
+          value: jdbc:postgresql://aas-registry-postgres.example.internal:5432/aas_registry
+
+  - it: wires an inline service-specific database secret into a backend service
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      aasRegistry.database.type: external
+      aasRegistry.database.host: aas-registry-postgres.example.internal
+      aasRegistry.database.port: "5432"
+      aasRegistry.database.dbname: aas_registry
+      aasRegistry.database.user: aas_registry
+      aasRegistry.database.password: change-me
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DBNAME
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-database
+                key: dbname
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-database
+                key: user
+          count: 1
+
   - it: wires generated inline external database secret into keycloak
     template: templates/keycloak/deployment.yaml
     set:

--- a/charts/basyx/tests/fixtures/invalid_database_type.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_type.yaml
@@ -1,0 +1,2 @@
+database:
+  type: sqlite

--- a/charts/basyx/tests/fixtures/invalid_external_database_empty_password.yaml
+++ b/charts/basyx/tests/fixtures/invalid_external_database_empty_password.yaml
@@ -1,0 +1,9 @@
+database:
+  type: external
+  existingSecret: ""
+  external:
+    host: postgres.example.internal
+    port: "5432"
+    dbname: basyx
+    user: basyx
+    password: ""

--- a/charts/basyx/tests/fixtures/invalid_external_database_missing_secret.yaml
+++ b/charts/basyx/tests/fixtures/invalid_external_database_missing_secret.yaml
@@ -1,0 +1,3 @@
+database:
+  type: external
+  existingSecret: ""

--- a/charts/basyx/tests/fixtures/invalid_external_database_sslmode.yaml
+++ b/charts/basyx/tests/fixtures/invalid_external_database_sslmode.yaml
@@ -1,0 +1,9 @@
+database:
+  type: external
+  external:
+    host: postgres.example.internal
+    port: "5432"
+    dbname: basyx
+    user: basyx
+    password: change-me
+    sslmode: invalid

--- a/charts/basyx/tests/fixtures/invalid_general_aasx_limits.yaml
+++ b/charts/basyx/tests/fixtures/invalid_general_aasx_limits.yaml
@@ -1,0 +1,7 @@
+general:
+  uploadMaxSizeBytes: 0
+  aasxMaxPartCount: 0
+  aasxMaxOPCMetadataSizeBytes: 0
+  aasxMaxPartExpandedSizeBytes: 0
+  aasxMaxTotalExpandedSizeBytes: 0
+  aasxMaxThumbnailSizeBytes: 0

--- a/charts/basyx/tests/fixtures/invalid_service_database_empty_password.yaml
+++ b/charts/basyx/tests/fixtures/invalid_service_database_empty_password.yaml
@@ -1,0 +1,8 @@
+aasRegistry:
+  database:
+    type: external
+    host: aas-registry-postgres.example.internal
+    port: "5432"
+    dbname: aas_registry
+    user: aas_registry
+    password: ""

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -74,6 +74,9 @@ tests:
           path: metadata.name
           value: basyx-keycloak-init
       - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.gitlab.com/gitlab-ci-utils/curl-jq:4.0.3
+      - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: http://basyx-keycloak:9096
       - equal:

--- a/charts/basyx/tests/keycloak_init_test.yaml
+++ b/charts/basyx/tests/keycloak_init_test.yaml
@@ -30,6 +30,39 @@ tests:
           path: data["user-profile.json"]
           pattern: '"unmanagedAttributePolicy":"ADMIN_EDIT"'
 
+  - it: renders Catena-X demo client and users for marker data loading
+    template: templates/keycloak-init-config.yaml
+    values:
+      - ../../../values/values.catena-x.example.yaml
+    documentSelector:
+      path: metadata.name
+      value: basyx-keycloak-init-config
+    asserts:
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"clientId":"basyx-ui"'
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"directAccessGrantsEnabled":true'
+      - matchRegex:
+          path: data["clients.json"]
+          pattern: '"multivalued":"false"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"username":"catena-x\.provider"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"role":\["view_digital_twin add_digital_twin update_digital_twin delete_digital_twin"\]'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"value":"change-me"'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"temporary":false'
+      - matchRegex:
+          path: data["users.json"]
+          pattern: '"Edc-Bpn":\["BPN_COMPANY_001"\]'
+
   - it: renders keycloak init job with release-scoped resources and secret refs
     template: templates/keycloak-init-job.yaml
     set:

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -79,6 +79,13 @@ tests:
       - failedTemplate:
           errorPattern: "general.bulkBatchLimit"
 
+  - it: fails when upload and AASX package limits are below one
+    values:
+      - fixtures/invalid_general_aasx_limits.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "general"
+
   - it: fails when server timeout is below one
     values:
       - fixtures/invalid_server_timeout.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -93,6 +93,27 @@ tests:
       - failedTemplate:
           errorPattern: "aasRepository.server.shutdownTimeoutSeconds"
 
+  - it: fails when external database has no existing secret
+    values:
+      - fixtures/invalid_external_database_missing_secret.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database"
+
+  - it: fails when inline external database password is empty
+    values:
+      - fixtures/invalid_external_database_empty_password.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database"
+
+  - it: fails when database type is unsupported
+    values:
+      - fixtures/invalid_database_type.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.type"
+
   - it: fails when ABAC policy scope contains unsupported characters
     values:
       - fixtures/invalid_abac_policy_scope.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -107,6 +107,13 @@ tests:
       - failedTemplate:
           errorPattern: "database"
 
+  - it: fails when external database sslmode is unsupported
+    values:
+      - fixtures/invalid_external_database_sslmode.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database"
+
   - it: fails when service-specific external database values are incomplete
     values:
       - fixtures/invalid_service_database_empty_password.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -107,6 +107,13 @@ tests:
       - failedTemplate:
           errorPattern: "database"
 
+  - it: fails when service-specific external database values are incomplete
+    values:
+      - fixtures/invalid_service_database_empty_password.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRegistry.database"
+
   - it: fails when database type is unsupported
     values:
       - fixtures/invalid_database_type.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -455,7 +455,20 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": ["postgres", "managed", "cnpg", "external"]
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": ["string", "number"] },
+            "dbname": { "type": "string" },
+            "user": { "type": "string" },
+            "password": { "type": "string" }
+          }
         },
         "instances": {
           "type": "integer",
@@ -471,7 +484,47 @@
             }
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "external" }
+            }
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "existingSecret": { "minLength": 1 }
+                },
+                "required": ["existingSecret"]
+              },
+              {
+                "properties": {
+                  "external": {
+                    "type": "object",
+                    "required": ["host", "port", "dbname", "user", "password"],
+                    "properties": {
+                      "host": { "minLength": 1 },
+                      "port": {
+                        "oneOf": [
+                          { "type": "integer", "minimum": 1 },
+                          { "type": "string", "minLength": 1 }
+                        ]
+                      },
+                      "dbname": { "minLength": 1 },
+                      "user": { "minLength": 1 },
+                      "password": { "minLength": 1 }
+                    }
+                  }
+                },
+                "required": ["external"]
+              }
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -9,6 +9,7 @@
         "server": { "$ref": "#/properties/server" },
         "history": { "$ref": "#/properties/history" },
         "eventing": { "$ref": "#/properties/eventing" },
+        "database": { "$ref": "#/definitions/serviceDatabase" },
         "abac": {
           "type": "object",
           "properties": {
@@ -28,6 +29,77 @@
         },
         "environment": { "type": "object" }
       }
+    },
+    "serviceDatabase": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["external"]
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "host": { "type": "string" },
+        "port": { "type": ["string", "number"] },
+        "dbname": { "type": "string" },
+        "user": { "type": "string" },
+        "password": { "type": "string" },
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": ["string", "number"] },
+            "dbname": { "type": "string" },
+            "user": { "type": "string" },
+            "password": { "type": "string" }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "existingSecret": { "minLength": 1 }
+          },
+          "required": ["existingSecret"]
+        },
+        {
+          "properties": {
+            "host": { "minLength": 1 },
+            "port": {
+              "oneOf": [
+                { "type": "integer", "minimum": 1 },
+                { "type": "string", "minLength": 1 }
+              ]
+            },
+            "dbname": { "minLength": 1 },
+            "user": { "minLength": 1 },
+            "password": { "minLength": 1 }
+          },
+          "required": ["host", "port", "dbname", "user", "password"]
+        },
+        {
+          "properties": {
+            "external": {
+              "type": "object",
+              "required": ["host", "port", "dbname", "user", "password"],
+              "properties": {
+                "host": { "minLength": 1 },
+                "port": {
+                  "oneOf": [
+                    { "type": "integer", "minimum": 1 },
+                    { "type": "string", "minLength": 1 }
+                  ]
+                },
+                "dbname": { "minLength": 1 },
+                "user": { "minLength": 1 },
+                "password": { "minLength": 1 }
+              }
+            }
+          },
+          "required": ["external"]
+        }
+      ]
     }
   },
   "required": [

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -366,7 +366,12 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "uploadMaxSizeBytes": { "type": "integer", "minimum": 0 },
+        "uploadMaxSizeBytes": { "type": "integer", "minimum": 1 },
+        "aasxMaxPartCount": { "type": "integer", "minimum": 1 },
+        "aasxMaxOPCMetadataSizeBytes": { "type": "integer", "minimum": 1 },
+        "aasxMaxPartExpandedSizeBytes": { "type": "integer", "minimum": 1 },
+        "aasxMaxTotalExpandedSizeBytes": { "type": "integer", "minimum": 1 },
+        "aasxMaxThumbnailSizeBytes": { "type": "integer", "minimum": 1 },
         "bulkBatchLimit": { "type": "integer", "minimum": 1 },
         "aasPreconfigPaths": {
           "type": "array",

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -45,6 +45,24 @@
         "dbname": { "type": "string" },
         "user": { "type": "string" },
         "password": { "type": "string" },
+        "sslmode": {
+          "type": "string",
+          "enum": ["", "disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+        },
+        "sslcert": { "type": "string" },
+        "sslkey": { "type": "string" },
+        "sslrootcert": { "type": "string" },
+        "connectTimeoutSeconds": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]*$" }
+          ]
+        },
+        "applicationName": { "type": "string" },
+        "fallbackApplicationName": { "type": "string" },
+        "searchPath": { "type": "string" },
+        "options": { "type": "string" },
+        "timezone": { "type": "string" },
         "external": {
           "type": "object",
           "properties": {
@@ -52,7 +70,25 @@
             "port": { "type": ["string", "number"] },
             "dbname": { "type": "string" },
             "user": { "type": "string" },
-            "password": { "type": "string" }
+            "password": { "type": "string" },
+            "sslmode": {
+              "type": "string",
+              "enum": ["", "disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+            },
+            "sslcert": { "type": "string" },
+            "sslkey": { "type": "string" },
+            "sslrootcert": { "type": "string" },
+            "connectTimeoutSeconds": {
+              "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string", "pattern": "^[0-9]*$" }
+              ]
+            },
+            "applicationName": { "type": "string" },
+            "fallbackApplicationName": { "type": "string" },
+            "searchPath": { "type": "string" },
+            "options": { "type": "string" },
+            "timezone": { "type": "string" }
           }
         }
       },
@@ -539,7 +575,25 @@
             "port": { "type": ["string", "number"] },
             "dbname": { "type": "string" },
             "user": { "type": "string" },
-            "password": { "type": "string" }
+            "password": { "type": "string" },
+            "sslmode": {
+              "type": "string",
+              "enum": ["", "disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+            },
+            "sslcert": { "type": "string" },
+            "sslkey": { "type": "string" },
+            "sslrootcert": { "type": "string" },
+            "connectTimeoutSeconds": {
+              "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string", "pattern": "^[0-9]*$" }
+              ]
+            },
+            "applicationName": { "type": "string" },
+            "fallbackApplicationName": { "type": "string" },
+            "searchPath": { "type": "string" },
+            "options": { "type": "string" },
+            "timezone": { "type": "string" }
           }
         },
         "instances": {

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1557,7 +1557,7 @@ database:
   #     password: change-me
   #     sslmode: require
   #     searchPath: registry_schema
-  # name for the cnpg cluster ressource
+  # name for the cnpg cluster resource
   # clusterName: "basyx-database"
   # name of database
   # database: "basyx"

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1522,6 +1522,22 @@ database:
     dbname: ""
     user: ""
     password: ""
+  # Backend services can override this global database connection individually:
+  #
+  # aasRegistry:
+  #   database:
+  #     existingSecret: basyx-aas-registry-postgres
+  #
+  # Or inline for test deployments:
+  #
+  # aasRegistry:
+  #   database:
+  #     type: external
+  #     host: postgres.example.internal
+  #     port: "5432"
+  #     dbname: basyx
+  #     user: basyx
+  #     password: change-me
   # name for the cnpg cluster ressource
   # clusterName: "basyx-database"
   # name of database

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1498,7 +1498,22 @@ aasWebGui:
 
 database:
   clusterName: basyx-database
+  # postgres, managed and cnpg deploy a CloudNativePG cluster. Use external to
+  # connect BaSyx Go to an existing PostgreSQL database through existingSecret.
   type: postgres
+  # Existing Secret for database.type=external. It must contain the keys:
+  # host, port, dbname, user and password.
+  existingSecret: ""
+  # Inline external database connection values for database.type=external.
+  # If existingSecret is set, these values are ignored.
+  # Prefer existingSecret for production and GitOps because inline passwords are
+  # stored in Helm release data.
+  external:
+    host: ""
+    port: "5432"
+    dbname: ""
+    user: ""
+    password: ""
   # name for the cnpg cluster ressource
   # clusterName: "basyx-database"
   # name of database

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -107,7 +107,12 @@ general:
   externalUrl: ""
   trustProxyHeaders: false
   trustedProxyCIDRs: []
-  uploadMaxSizeBytes: 0
+  uploadMaxSizeBytes: 134217728
+  aasxMaxPartCount: 10000
+  aasxMaxOPCMetadataSizeBytes: 16777216
+  aasxMaxPartExpandedSizeBytes: 134217728
+  aasxMaxTotalExpandedSizeBytes: 134217728
+  aasxMaxThumbnailSizeBytes: 16777216
   bulkBatchLimit: 1000
   # Comma-rendered into GENERAL_AAS_PRECONFIG_PATHS. Mount matching files or
   # directories with the service-specific volumes/volumeMounts when used.
@@ -230,9 +235,9 @@ keycloak:
   webUiClientId: basyx-ui
   initJob:
     image:
-      repository: peterevans/curl-jq
+      repository: registry.gitlab.com/gitlab-ci-utils/curl-jq
       pullPolicy: IfNotPresent
-      tag: "1.0"
+      tag: "4.0.3"
       digest: ""
   tests:
     realmCheck:
@@ -1369,7 +1374,7 @@ aasWebGui:
   image:
     repository: eclipsebasyx/aas-gui
     pullPolicy: Always
-    tag: v2-260707
+    tag: v2-260721
   imagePullSecrets: []
   nameOverride: "aas-gui"
   fullnameOverride: "aas-gui"

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1522,6 +1522,18 @@ database:
     dbname: ""
     user: ""
     password: ""
+    # Optional BaSyx Go PostgreSQL settings. These are rendered as optional
+    # POSTGRES_* environment variables for backend services.
+    # sslmode: require
+    # sslcert: /etc/ssl/certs/postgres/client.crt
+    # sslkey: /etc/ssl/certs/postgres/client.key
+    # sslrootcert: /etc/ssl/certs/postgres/ca.crt
+    # connectTimeoutSeconds: 10
+    # applicationName: basyx-go
+    # fallbackApplicationName: basyx-go
+    # searchPath: basyx
+    # options: "-c statement_timeout=30000"
+    # timezone: UTC
   # Backend services can override this global database connection individually:
   #
   # aasRegistry:
@@ -1538,6 +1550,8 @@ database:
   #     dbname: basyx
   #     user: basyx
   #     password: change-me
+  #     sslmode: require
+  #     searchPath: registry_schema
   # name for the cnpg cluster ressource
   # clusterName: "basyx-database"
   # name of database

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1432,6 +1432,14 @@ aasWebGui:
   environment:
     LOGO_LIGHT_PATH: BaSyx_Logo.svg
     LOGO_DARK_PATH: BaSyx_Logo.svg
+  # Environment values that should be stored in a Kubernetes Secret and exposed
+  # to the UI container through envFrom.secretRef. Use this for server-side
+  # credentials such as EDC API keys.
+  secretEnvironment: {}
+  # Reference an existing Secret instead of rendering secretEnvironment.
+  # The Secret must live in the same namespace and contain environment variable
+  # names as keys.
+  existingSecretEnvironment: ""
 
 
   ingress:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1515,7 +1515,7 @@ database:
   # connect BaSyx Go to an existing PostgreSQL database through existingSecret.
   type: postgres
   # Existing Secret for database.type=external. It must contain the keys:
-  # host, port, dbname, user and password.
+  # host, port, dbname, user, password and jdbc-uri.
   existingSecret: ""
   # Inline external database connection values for database.type=external.
   # If existingSecret is set, these values are ignored.

--- a/examples/postman/basyx-catena-x-marker-access.postman_collection.json
+++ b/examples/postman/basyx-catena-x-marker-access.postman_collection.json
@@ -1,0 +1,568 @@
+{
+  "info": {
+    "name": "BaSyx Catena-X Marker Access",
+    "description": "Postman collection for the BaSyx Go Catena-X marker access example. Set baseUrl to your ingress host, run the Auth folder first, then Setup - Write Example Data. The JSON payloads are based on BaSyxMarkerAccessExample and use the default paths from values.catena-x.example.yaml.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://basyx.example.com",
+      "type": "string"
+    },
+    {
+      "key": "realm",
+      "value": "basyx",
+      "type": "string"
+    },
+    {
+      "key": "clientId",
+      "value": "basyx-ui",
+      "type": "string"
+    },
+    {
+      "key": "providerUsername",
+      "value": "catena-x.provider",
+      "type": "string"
+    },
+    {
+      "key": "providerPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "partnerAUsername",
+      "value": "catena-x.partner-a",
+      "type": "string"
+    },
+    {
+      "key": "partnerAPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "partnerBUsername",
+      "value": "catena-x.partner-b",
+      "type": "string"
+    },
+    {
+      "key": "partnerBPassword",
+      "value": "change-me",
+      "type": "string"
+    },
+    {
+      "key": "aasIdBase64",
+      "value": "dXJuOmV4YW1wbGU6YWFzOnByb2R1Y3QtMDAx",
+      "type": "string"
+    },
+    {
+      "key": "publicSubmodelIdBase64",
+      "value": "dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+      "type": "string"
+    },
+    {
+      "key": "restrictedSubmodelIdBase64",
+      "value": "dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
+      "type": "string"
+    },
+    {
+      "key": "providerToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "partnerAToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "partnerBToken",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Get provider token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{providerUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{providerPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('provider token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('providerToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get partner A token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{partnerAUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{partnerAPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('partner A token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('partnerAToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get partner B token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{clientId}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{partnerBUsername}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{partnerBPassword}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{baseUrl}}/identity-management/realms/{{realm}}/protocol/openid-connect/token"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('partner B token issued', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('partnerBToken', json.access_token);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Setup - Write Example Data",
+      "item": [
+        {
+          "name": "Cleanup - Delete shell descriptor",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors/{{aasIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete shell descriptor is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Cleanup - Delete public submodel",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete public submodel is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Cleanup - Delete restricted submodel",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('delete restricted submodel is ok or not found', function () { pm.expect([204, 404]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post shell descriptor to DTR",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"idShort\":\"ProductTwin\",\"id\":\"urn:example:aas:product-001\",\"description\":[{\"language\":\"en\",\"text\":\"Public and partner-restricted submodel descriptors.\"}],\"globalAssetId\":\"urn:example:asset:product-001\",\"specificAssetIds\":[{\"name\":\"manufacturerPartId\",\"value\":\"PART-001\",\"externalSubjectId\":{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}},{\"name\":\"customerPartId\",\"value\":\"CUSTOMER-PART-001\",\"externalSubjectId\":{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}}],\"submodelDescriptors\":[{\"idShort\":\"PublicNameplate\",\"id\":\"urn:example:submodel:nameplate\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}],\"endpoints\":[{\"interface\":\"SUBMODEL-3.0\",\"protocolInformation\":{\"href\":\"{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}\",\"endpointProtocol\":\"HTTP\"}}]},{\"idShort\":\"RestrictedSerialPartTypization\",\"id\":\"urn:example:submodel:serial-part-typization\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}],\"endpoints\":[{\"interface\":\"SUBMODEL-3.0\",\"protocolInformation\":{\"href\":\"{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}\",\"endpointProtocol\":\"HTTP\"}}]}]}"
+            },
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('shell descriptor created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post public submodel",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"urn:example:submodel:nameplate\",\"idShort\":\"PublicNameplate\",\"modelType\":\"Submodel\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"PUBLIC_READABLE\"}]}],\"submodelElements\":[{\"idShort\":\"ManufacturerName\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"Example Corp\"}]}"
+            },
+            "url": "{{baseUrl}}/submodel-repo/submodels"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('public submodel created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Post restricted submodel",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"urn:example:submodel:serial-part-typization\",\"idShort\":\"RestrictedSerialPartTypization\",\"modelType\":\"Submodel\",\"supplementalSemanticIds\":[{\"type\":\"ExternalReference\",\"keys\":[{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_001\"},{\"type\":\"GlobalReference\",\"value\":\"BPN_COMPANY_002\"}]}],\"submodelElements\":[{\"idShort\":\"PublicPartType\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"PUBLIC-TYPE\"},{\"idShort\":\"PartnerSerialNumber\",\"modelType\":\"Property\",\"valueType\":\"xs:string\",\"value\":\"SECRET-001\"}]}"
+            },
+            "url": "{{baseUrl}}/submodel-repo/submodels"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('restricted submodel created', function () { pm.expect([201, 409]).to.include(pm.response.code); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Read - Provider",
+      "item": [
+        {
+          "name": "Provider - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('provider can read descriptors', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Provider - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        },
+        {
+          "name": "Provider - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{providerToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Partner A",
+      "item": [
+        {
+          "name": "Partner A - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Partner A - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        },
+        {
+          "name": "Partner A - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerAToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Partner B",
+      "item": [
+        {
+          "name": "Partner B - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerBToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Partner B - Get restricted submodel",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{partnerBToken}}"
+              }
+            ],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{restrictedSubmodelIdBase64}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Read - Anonymous",
+      "item": [
+        {
+          "name": "Anonymous - Get shell descriptors",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/digital-twin-registry/shell-descriptors"
+          }
+        },
+        {
+          "name": "Anonymous - Get public submodel",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/submodel-repo/submodels/{{publicSubmodelIdBase64}}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -692,7 +692,7 @@ aasWebGui:
           digitalTwinRegistry:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
           submodelService:
-            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
         security:
           type: oauth2
           config:

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -1,0 +1,704 @@
+# Example values for a Catena-X oriented BaSyx Go deployment.
+#
+# This setup focuses on the marker-based Digital Twin Registry and Submodel
+# Repository access pattern used by the BaSyx Go Catena-X examples:
+#
+# - Digital Twin Registry visibility is controlled through
+#   specificAssetIds[].externalSubjectId.keys[].value and
+#   submodelDescriptors[].supplementalSemanticIds[].keys[].value.
+# - Submodel Repository visibility is controlled through
+#   supplementalSemanticIds[].keys[].value on submodels and submodel elements.
+# - PUBLIC_READABLE marks data that can be read without a matching BPN.
+# - BPN values are read from the token claim Edc-Bpn.
+#
+# Copy this file and adapt it for your own cluster:
+#
+#   cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
+#
+# Do not commit real passwords, client secrets or private certificate material.
+
+instanceName: catena-x
+host: basyx.example.com
+
+fullnameOverride: basyx
+
+tls:
+  enabled: true
+  hosts:
+    - basyx.example.com
+
+internal:
+  CACertificates:
+    trustStore:
+      useDefaultCAs: true
+      chartFileDirectory: ""
+      additionalCACertificates: ""
+  certificateIssuer:
+    name: internal-issuer
+    autocreateCa: true
+    autocreateCaSecretName: internal-issuer-ca
+    spec:
+      ca:
+        secretName: internal-issuer-ca
+
+ingress:
+  # Use this issuer when the chart should create and use its own internal CA.
+  issuer: internal-issuer
+
+database:
+  clusterName: basyx-database
+  instances: 1
+  storage:
+    size: 10Gi
+
+configurationService:
+  enabled: true
+
+environment:
+  common:
+    ABAC_ENABLED: true
+
+keycloak:
+  enabled: true
+  secrets:
+    admin:
+      username: admin
+      password: change-me
+    client:
+      name: basyx-ui
+      clientPassword: change-me
+  initialization:
+    roles:
+      - view_digital_twin
+      - add_digital_twin
+      - update_digital_twin
+      - delete_digital_twin
+    clients:
+      - clientId: basyx-ui
+        publicClient: true
+        standardFlowEnabled: true
+        implicitFlowEnabled: true
+        # Enabled for demo data loading with the upstream Postman collection or
+        # curl examples. Disable this in production and use authorization code
+        # flow or another trusted token issuing flow instead.
+        directAccessGrantsEnabled: true
+        redirectUris:
+          - "https://{{ .Values.host }}{{ .Values.paths.aasWebUiBasePath }}/*"
+        webOrigins:
+          - "+"
+        attributes:
+          post.logout.redirect.uris: "https://{{ .Values.host }}{{ .Values.paths.aasWebUiBasePath }}/*"
+          oauth2.device.authorization.grant.enabled: "true"
+        protocolMappers:
+          - name: Role Mapper
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              aggregate.attrs: "false"
+              introspection.token.claim: "true"
+              multivalued: "false"
+              userinfo.token.claim: "true"
+              user.attribute: role
+              id.token.claim: "true"
+              lightweight.claim: "false"
+              access.token.claim: "true"
+              claim.name: role
+              jsonType.label: String
+          - name: Edc BPN Mapper
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              aggregate.attrs: "false"
+              introspection.token.claim: "true"
+              multivalued: "false"
+              userinfo.token.claim: "true"
+              user.attribute: Edc-Bpn
+              id.token.claim: "true"
+              lightweight.claim: "false"
+              access.token.claim: "true"
+              claim.name: Edc-Bpn
+              jsonType.label: String
+          - name: discovery-service-aud-mapper
+            protocol: openid-connect
+            protocolMapper: oidc-audience-mapper
+            consentRequired: false
+            config:
+              included.client.audience: discovery-service
+              id.token.claim: "false"
+              lightweight.claim: "false"
+              introspection.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "false"
+      - clientId: discovery-service
+        serviceAccountsEnabled: true
+    users:
+      - username: catena-x.provider
+        enabled: true
+        email: provider@example.com
+        firstName: Catena-X
+        lastName: Provider
+        emailVerified: true
+        attributes:
+          # Keep role as one string value. BaSyx Go ABAC $contains evaluates
+          # strings and unwraps multi-value claims to their first entry.
+          role:
+            - view_digital_twin add_digital_twin update_digital_twin delete_digital_twin
+          Edc-Bpn:
+            - BPN_PROVIDER
+        roles:
+          - view_digital_twin
+          - add_digital_twin
+          - update_digital_twin
+          - delete_digital_twin
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+      - username: catena-x.partner-a
+        enabled: true
+        email: partner-a@example.com
+        firstName: Catena-X
+        lastName: Partner A
+        emailVerified: true
+        attributes:
+          Edc-Bpn:
+            - BPN_COMPANY_001
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+      - username: catena-x.partner-b
+        enabled: true
+        email: partner-b@example.com
+        firstName: Catena-X
+        lastName: Partner B
+        emailVerified: true
+        attributes:
+          Edc-Bpn:
+            - BPN_COMPANY_002
+        credentials:
+          - type: password
+            value: change-me
+            temporary: false
+
+abac:
+  enabled: true
+
+digitalTwinRegistry:
+  enabled: true
+  general:
+    # Accept singular supplementalSemanticId input for compatibility with
+    # Catena-X/Tractus-X payload variants while emitting supplementalSemanticIds.
+    supportsSingularSupplementalSemanticId: true
+    # Keep this disabled for production. If a trusted ingress or connector maps
+    # Edc-Bpn into a token claim, the service does not need header injection.
+    enableCustomMiddlewareHeaderInjection: false
+  abac:
+    accessRules: |-
+      {
+        "AllAccessPermissionRules": {
+          "DEFATTRIBUTES": [
+            {
+              "name": "anonymous",
+              "attributes": [
+                { "GLOBAL": "ANONYMOUS" }
+              ]
+            }
+          ],
+          "DEFOBJECTS": [
+            {
+              "name": "all_routes",
+              "objects": [
+                { "ROUTE": "*" }
+              ]
+            },
+            {
+              "name": "all_shell_descriptors",
+              "objects": [
+                { "DESCRIPTOR": "$aasdesc(\"*\")" }
+              ]
+            },
+            {
+              "name": "asset_links",
+              "objects": [
+                { "ROUTE": "/lookup/shells" },
+                { "ROUTE": "/lookup/shellsByAssetLink" },
+                { "ROUTE": "{{ .Values.paths.digitalTwinRegistry }}/lookup/shells" },
+                { "ROUTE": "{{ .Values.paths.digitalTwinRegistry }}/lookup/shellsByAssetLink" }
+              ]
+            }
+          ],
+          "DEFACLS": [
+            {
+              "name": "read",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["READ"],
+                "ACCESS": "ALLOW"
+              }
+            },
+            {
+              "name": "write",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["CREATE", "UPDATE", "DELETE"],
+                "ACCESS": "ALLOW"
+              }
+            }
+          ],
+          "DEFFORMULAS": [
+            {
+              "name": "data_provider_read",
+              "formula": {
+                "$contains": [
+                  { "$attribute": { "CLAIM": "role" } },
+                  { "$strVal": "view_digital_twin" }
+                ]
+              }
+            },
+            {
+              "name": "data_provider",
+              "formula": {
+                "$or": [
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "add_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "update_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "delete_digital_twin" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_match",
+              "formula": {
+                "$eq": [
+                  { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                  { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                ]
+              }
+            },
+            {
+              "name": "aas_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$aasdesc#specificAssetIds[].externalSubjectId.keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_descriptor_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_descriptor_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "rules": [
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["all_shell_descriptors", "asset_links"],
+              "USEFORMULA": "data_provider_read"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_routes"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_shell_descriptors"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["all_shell_descriptors"],
+              "USEFORMULA": "aas_bpn_or_public",
+              "FILTERLIST": [
+                { "FRAGMENT": "$aasdesc#administration", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#displayName", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#description", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#assetKind", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#assetType", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#globalAssetId", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#idShort", "USEFORMULA": "aas_bpn_match" },
+                { "FRAGMENT": "$aasdesc#specificAssetIds[]", "USEFORMULA": "aas_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#specificAssetIds[].externalSubjectId.keys[]", "USEFORMULA": "aas_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[]", "USEFORMULA": "submodel_descriptor_bpn_or_public", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[]", "USEFORMULA": "submodel_descriptor_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$aasdesc#submodelDescriptors[].supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_descriptor_bpn_or_public_with_claim", "MATCH": true }
+              ]
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["asset_links"],
+              "USEFORMULA": "aas_bpn_or_public"
+            }
+          ]
+        }
+      }
+
+submodelRepository:
+  enabled: true
+  environment:
+    # The Catena-X marker example uses the Submodel Repository directly without
+    # a separate Submodel Registry.
+    GENERAL_SUBMODELREGISTRYINTEGRATION: false
+    GENERAL_EXTERNALURL: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
+  general:
+    # Keep this disabled for production. Use a signed token claim or a trusted
+    # ingress/connector mapping for Edc-Bpn instead.
+    enableCustomMiddlewareHeaderInjection: false
+  abac:
+    accessRules: |-
+      {
+        "AllAccessPermissionRules": {
+          "DEFATTRIBUTES": [
+            {
+              "name": "anonymous",
+              "attributes": [
+                { "GLOBAL": "ANONYMOUS" }
+              ]
+            }
+          ],
+          "DEFOBJECTS": [
+            {
+              "name": "all_routes",
+              "objects": [
+                { "ROUTE": "*" }
+              ]
+            },
+            {
+              "name": "submodel_routes",
+              "objects": [
+                { "ROUTE": "/submodels" },
+                { "ROUTE": "/submodels/*" },
+                { "ROUTE": "/submodels/*/submodel-elements" },
+                { "ROUTE": "/submodels/*/submodel-elements/*" },
+                { "ROUTE": "/query/submodels" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*/submodel-elements" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*/submodel-elements/*" },
+                { "ROUTE": "{{ .Values.paths.submodelRepository }}/query/submodels" }
+              ]
+            }
+          ],
+          "DEFACLS": [
+            {
+              "name": "read",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["READ"],
+                "ACCESS": "ALLOW"
+              }
+            },
+            {
+              "name": "write",
+              "acl": {
+                "USEATTRIBUTES": "anonymous",
+                "RIGHTS": ["CREATE", "UPDATE", "DELETE"],
+                "ACCESS": "ALLOW"
+              }
+            }
+          ],
+          "DEFFORMULAS": [
+            {
+              "name": "data_provider_read",
+              "formula": {
+                "$contains": [
+                  { "$attribute": { "CLAIM": "role" } },
+                  { "$strVal": "view_digital_twin" }
+                ]
+              }
+            },
+            {
+              "name": "data_provider",
+              "formula": {
+                "$or": [
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "add_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "update_digital_twin" }
+                    ]
+                  },
+                  {
+                    "$contains": [
+                      { "$attribute": { "CLAIM": "role" } },
+                      { "$strVal": "delete_digital_twin" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$sm#supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_element_bpn_or_public",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      { "$strVal": "PUBLIC_READABLE" },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "submodel_element_bpn_or_public_with_claim",
+              "formula": {
+                "$or": [
+                  {
+                    "$eq": [
+                      { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                      { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                    ]
+                  },
+                  {
+                    "$and": [
+                      {
+                        "$eq": [
+                          { "$strVal": "PUBLIC_READABLE" },
+                          { "$field": "$sme#supplementalSemanticIds[].keys[].value" }
+                        ]
+                      },
+                      {
+                        "$ne": [
+                          { "$attribute": { "CLAIM": "Edc-Bpn" } },
+                          { "$strVal": "" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "rules": [
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["submodel_routes"],
+              "USEFORMULA": "data_provider_read"
+            },
+            {
+              "USEACL": "write",
+              "USEOBJECTS": ["all_routes"],
+              "USEFORMULA": "data_provider"
+            },
+            {
+              "USEACL": "read",
+              "USEOBJECTS": ["submodel_routes"],
+              "USEFORMULA": "submodel_bpn_or_public",
+              "FILTERLIST": [
+                { "FRAGMENT": "$sm#supplementalSemanticIds[]", "USEFORMULA": "submodel_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sm#supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sme", "USEFORMULA": "submodel_element_bpn_or_public", "MATCH": true },
+                { "FRAGMENT": "$sme#supplementalSemanticIds[]", "USEFORMULA": "submodel_element_bpn_or_public_with_claim", "MATCH": true },
+                { "FRAGMENT": "$sme#supplementalSemanticIds[].keys[]", "USEFORMULA": "submodel_element_bpn_or_public_with_claim", "MATCH": true }
+              ]
+            }
+          ]
+        }
+      }
+
+aasDiscovery:
+  enabled: false
+
+aasRegistry:
+  enabled: false
+
+aasRepository:
+  enabled: false
+
+aasEnvironment:
+  enabled: false
+
+dppApi:
+  enabled: false
+
+submodelRegistry:
+  enabled: false
+
+cdRepository:
+  enabled: false
+
+aasWebGui:
+  enabled: true
+  environment:
+    START_PAGE_ROUTE_NAME: CatenaXplorer
+  infrastructureConfig:
+    infrastructures:
+      main: null
+      default: catena-x
+      catena-x:
+        name: "Catena-X BaSyx Go {{ .Values.instanceName }}"
+        template: catena-x
+        components:
+          digitalTwinRegistry:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
+          submodelService:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+        security:
+          type: oauth2
+          config:
+            flow: auth_code
+            issuer: "https://{{ .Values.host }}{{ .Values.paths.keycloak }}/realms/{{ .Values.keycloak.realm }}"
+            clientId: "{{ .Values.keycloak.secrets.client.name }}"
+
+companyLookup:
+  enabled: false

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -681,6 +681,35 @@ aasWebGui:
   enabled: true
   environment:
     START_PAGE_ROUTE_NAME: CatenaXplorer
+    ALLOW_EDITING: "false"
+    ALLOW_UPLOADING: "false"
+    ALLOW_LOGOUT: "true"
+    SM_VIEWER_EDITOR: "true"
+    AUTHORIZATION_HEADER_PREFIX: Bearer
+    AUTHORIZATION_HEADER_DESCRIPTION_ENDPOINT_EXEMPTION: "true"
+    # Server-side CatenaXplorer EDC backend-for-frontend settings.
+    # These values follow the BaSyx AAS Web UI CatenaXplorerEdcStandalone example.
+    CX_EDC_BFF_ENABLED: "true"
+    CX_EDC_BFF_PORT: "3001"
+    CX_EDC_BFF_UPSTREAM_URL: "http://127.0.0.1:3001"
+    CX_EDC_BFF_AUTH_MODE: none
+    CX_EDC_BFF_AUTH_JWKS_URL: ""
+    CX_EDC_BFF_AUTH_ISSUER: ""
+    CX_EDC_BFF_AUTH_AUDIENCE: ""
+    CX_EDC_BFF_REQUIRED_ROLES: ""
+    CX_EDC_DEFAULT_MANAGEMENT_URL: "https://consumer-edc.example.com/management"
+    CX_EDC_DEFAULT_API_KEY_HEADER: X-Api-Key
+    CX_EDC_DEFAULT_PARTICIPANT_ID: ""
+    CX_EDC_DEFAULT_DSP_ENDPOINT: "https://consumer-edc.example.com/api/v1/dsp"
+    CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES: "https://provider-edc.example.com/api/v1/dsp"
+    CX_EDC_ALLOW_INSECURE_COUNTER_PARTY_ADDRESSES: "false"
+    CX_EDC_REQUEST_TIMEOUT_MS: "30000"
+    CX_EDC_EDR_POLLING_ATTEMPTS: "60"
+    CX_EDC_EDR_POLLING_INTERVAL_MS: "2000"
+  secretEnvironment:
+    # Replace this placeholder in a private overlay or use
+    # aasWebGui.existingSecretEnvironment for production.
+    CX_EDC_DEFAULT_API_KEY: ""
   infrastructureConfig:
     infrastructures:
       main: null

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -721,7 +721,7 @@ aasWebGui:
           digitalTwinRegistry:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
           submodelService:
-            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
           companyLookup:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.companyLookup }}"
         security:

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -721,7 +721,9 @@ aasWebGui:
           digitalTwinRegistry:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
           submodelService:
-            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}/submodels"
+          companyLookup:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.companyLookup }}"
         security:
           type: oauth2
           config:
@@ -730,4 +732,4 @@ aasWebGui:
             clientId: "{{ .Values.keycloak.secrets.client.name }}"
 
 companyLookup:
-  enabled: false
+  enabled: true

--- a/values/values.example.yaml
+++ b/values/values.example.yaml
@@ -102,12 +102,14 @@ aasWebGui:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
           conceptDescriptionRepository:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.cdRepository }}"
+          companyLookup:
+            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.companyLookup }}"
         security:
           type: None
           config: null
 
 companyLookup:
-  enabled: false
+  enabled: true
 
 
 digitalTwinRegistry:

--- a/values/values.external-db.example.yaml
+++ b/values/values.external-db.example.yaml
@@ -1,0 +1,21 @@
+# Example overlay for using an existing PostgreSQL database.
+#
+# Create the referenced Secret in the target namespace before installing the
+# chart. The Secret must contain the keys: host, port, dbname, user, password.
+
+database:
+  type: external
+  existingSecret: basyx-external-postgres
+
+  # Alternative for simple test deployments:
+  # Leave existingSecret empty and provide the connection values inline. The
+  # chart renders a Secret from these values. For production and GitOps setups,
+  # prefer existingSecret because inline passwords are stored in Helm release
+  # data and should not be committed to Git.
+  # existingSecret: ""
+  # external:
+  #   host: postgres.example.internal
+  #   port: "5432"
+  #   dbname: basyx
+  #   user: basyx
+  #   password: change-me

--- a/values/values.external-db.example.yaml
+++ b/values/values.external-db.example.yaml
@@ -1,7 +1,10 @@
 # Example overlay for using an existing PostgreSQL database.
 #
 # Create the referenced Secret in the target namespace before installing the
-# chart. The Secret must contain the keys: host, port, dbname, user, password.
+# chart. The Secret must contain the keys: host, port, dbname, user, password,
+# jdbc-uri. Optional BaSyx Go keys include sslmode, sslcert, sslkey,
+# sslrootcert, connectTimeoutSeconds, applicationName,
+# fallbackApplicationName, searchPath, options and timezone.
 
 database:
   type: external
@@ -19,3 +22,12 @@ database:
   #   dbname: basyx
   #   user: basyx
   #   password: change-me
+  #   sslmode: require
+  #   searchPath: basyx
+
+# External PostgreSQL databases are usually managed independently. Disable the
+# Configuration Service wait initContainer when the database is expected to be
+# reachable before this chart is installed.
+configurationService:
+  waitForDatabase:
+    enabled: false


### PR DESCRIPTION
## Summary

This PR addresses #75 by adding a Catena-X oriented BaSyx Go Helm chart example and extending the chart with support for existing external PostgreSQL databases.

It also updates the chart for the latest BaSyx Go and BaSyx AAS Web UI releases, configures the AAS Web UI for CatenaXplorer/EDC use cases, and documents the end-to-end Catena-X and external database setup.

## Changes

### Catena-X Example

- Add `values/values.catena-x.example.yaml` for a Catena-X oriented deployment.
- Configure Digital Twin Registry and Submodel Repository for marker-based ABAC.
- Configure Keycloak demo users for provider and partner access scenarios.
- Configure the AAS Web UI with the `catena-x` infrastructure template.
- Add CatenaXplorer EDC UI runtime settings based on the upstream AAS Web UI `CatenaXplorerEdcStandalone` example.
- Add Company Lookup to the AAS Web UI infrastructure examples and enable the Company Lookup service where referenced.
- Correct the Catena-X AAS Web UI `submodelService` endpoint to point at the Submodel Repository `/submodels` API path.
- Add a Catena-X marker access Postman collection.

### External PostgreSQL Support

- Add support for `database.type=external` to use an existing PostgreSQL database instead of rendering a CloudNativePG cluster.
- Add `values/values.external-db.example.yaml` for external PostgreSQL deployments.
- Keep the existing managed CloudNativePG database mode as the default for backwards compatibility.
- Add support for service-specific database overrides, so individual BaSyx Go backend services can use their own external PostgreSQL Secret or inline database configuration.
- Add support for advanced external PostgreSQL options such as `sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `connectTimeoutSeconds`, `applicationName`, `fallbackApplicationName`, `searchPath`, `options`, and `timezone`.
- Render optional PostgreSQL Secret keys as optional `POSTGRES_*` environment variables for BaSyx Go backend services.
- Generate JDBC URLs with PostgreSQL parameters for inline external database values, including `sslmode` and `currentSchema` derived from `searchPath`.
- Ensure Keycloak uses `KC_DB=postgres` while still reading its JDBC URL from the selected database Secret.
- Disable the Configuration Service database wait initContainer in the external DB example overlay, because external databases are usually managed independently.

### AAS Web UI Configuration

- Add Secret-based AAS Web UI environment support via `aasWebGui.secretEnvironment` and `aasWebGui.existingSecretEnvironment`.
- Update the AAS Web UI image tag to `v2-260721`.
- Add Company Lookup to the default AAS Web UI infrastructure example.

### BaSyx Go Release Configuration

- Update the chart to BaSyx chart version `3.3.0`.
- Update the BaSyx Go app version to `1.0.3`.
- Add new BaSyx Go runtime values for upload and AASX package limits:
  - `general.uploadMaxSizeBytes`
  - `general.aasxMaxPartCount`
  - `general.aasxMaxOPCMetadataSizeBytes`
  - `general.aasxMaxPartExpandedSizeBytes`
  - `general.aasxMaxTotalExpandedSizeBytes`
  - `general.aasxMaxThumbnailSizeBytes`
- Render the new upload and AASX package limit settings as `GENERAL_*` environment variables.
- Validate the new upload and AASX package limit settings through the values schema.
- Render large numeric config values without scientific notation so generated environment variables remain valid.
- Update the Keycloak init curl/jq image and assert the rendered image in Helm unit tests.

### Documentation And Tests

- Document external PostgreSQL usage, Secret requirements, optional PostgreSQL settings, inline test values, service-specific database overrides, Catena-X setup, and the new upload/AASX package limit settings.
- Add Helm unit tests for Catena-X ABAC, UI configuration, EDC UI environment, external database wiring, service-specific database overrides, advanced PostgreSQL options, release config values, AASX package limits, and schema validation.
- Extend chart test coverage in CI.

## Validation

```bash
helm lint charts/basyx -f values/values.catena-x.example.yaml
helm lint charts/basyx -f values/values.external-db.example.yaml
helm lint charts/basyx -f values/values.catena-x.example.yaml -f values/values.external-db.example.yaml
helm unittest charts/basyx

Closes #75 