### PR TITLE
Make BaSyx ingress configuration controller-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You need:
 
 - A Kubernetes cluster and a working `kubectl` context
 - Helm 3
-- An ingress controller, usually nginx ingress
+- An ingress controller, for example nginx ingress or Azure Application Gateway Ingress Controller
 - cert-manager, because the chart renders `cert-manager.io/v1` resources
 - CloudNativePG, because the chart renders `postgresql.cnpg.io/v1` database clusters
 - Optional: `helm-unittest` for local chart tests
@@ -350,12 +350,41 @@ CloudNativePG database PVCs and manually created secrets may need separate clean
 | --- | --- |
 | `tls.enabled` | Enables TLS-related mounts and ingress TLS rendering. |
 | `tls.hosts` | Hosts included in rendered TLS resources. |
+| `tls.secretName` | Existing TLS Secret used by all generated ingress resources. Defaults to `<release-name>-tls-secret` when empty. |
+| `ingress.className` | Global `spec.ingressClassName` default inherited by all service ingress resources. Defaults to `nginx`. |
+| `ingress.annotations` | Global ingress annotations merged into all service ingress resources. Service-local annotations override global annotations. |
 | `ingress.issuer` | Existing namespaced cert-manager issuer for ingress certificates. |
 | `ingress.clusterIssuer` | Existing cluster issuer for ingress certificates. |
 | `internal.certificateIssuer.autocreateCa` | Creates an internal self-signed CA and issuer. |
 | `internal.certificateIssuer.name` | Internal issuer name used by generated certificates. |
 
 The chart sets `spec.privateKey.rotationPolicy: Always` on the generated CA certificate to avoid cert-manager v1.18+ default-change warnings.
+
+### Ingress Controllers
+
+The chart defaults to nginx ingress, but the generated Kubernetes Ingress resources are not nginx-specific. Configure another ingress controller globally with `ingress.className` and `ingress.annotations`; individual services can still override those settings under `<service>.ingress`.
+
+Example for Azure Application Gateway Ingress Controller:
+
+```yaml
+host: basyx.example.com
+
+tls:
+  enabled: true
+  secretName: tls-secret
+  hosts:
+    - "{{ .Values.host }}"
+
+ingress:
+  className: azure-application-gateway
+  clusterIssuer: letsencrypt
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: null
+```
+
+`null` removes an inherited default annotation. This is useful when switching away from nginx and avoiding nginx-specific annotations on non-nginx controllers.
 
 ### Additional CA Certificates
 

--- a/README.md
+++ b/README.md
@@ -379,12 +379,11 @@ ingress:
   className: azure-application-gateway
   clusterIssuer: letsencrypt
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: null
 ```
 
-`null` removes an inherited default annotation. This is useful when switching away from nginx and avoiding nginx-specific annotations on non-nginx controllers.
+Use `ingress.className` for AGIC instead of the legacy `kubernetes.io/ingress.class` annotation. Kubernetes rejects manifests when both values are set and do not match exactly. `null` removes an inherited default annotation, which is useful when switching away from nginx and avoiding nginx-specific annotations on non-nginx controllers.
 
 ### Additional CA Certificates
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ The chart sets `spec.privateKey.rotationPolicy: Always` on the generated CA cert
 
 The chart defaults to nginx ingress, but the generated Kubernetes Ingress resources are not nginx-specific. Configure another ingress controller globally with `ingress.className` and `ingress.annotations`; individual services can still override those settings under `<service>.ingress`.
 
+Service routes use Kubernetes `pathType: Prefix` by default because it is portable across common ingress controllers. Override `<service>.ingress.hosts[].paths[].pathType` only when your controller explicitly requires another mode such as `ImplementationSpecific`.
+
 Example for Azure Application Gateway Ingress Controller:
 
 ```yaml

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.3.0
+version: 3.3.1
 appVersion: "1.0.3"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -780,9 +780,61 @@ Helper to render TLS block if enabled
 tls:
   - hosts:
       {{- range .Values.tls.hosts }}
-      - {{ . | quote }}
+      - {{ tpl (print .) $ | quote }}
       {{- end }}
-    secretName: {{ .Release.Name }}-tls-secret
+    secretName: {{ .Values.tls.secretName | default (printf "%s-tls-secret" .Release.Name) | quote }}
+{{- end }}
+{{- end }}
+
+{{- define "common.ingress.className" -}}
+{{- $root := .root -}}
+{{- $ingress := .ingress | default dict -}}
+{{- $className := $root.Values.ingress.className | default "" -}}
+{{- with $ingress.className -}}
+{{- $className = . -}}
+{{- end -}}
+{{- if $className }}
+ingressClassName: {{ tpl (print $className) $root | quote }}
+{{- end }}
+{{- end }}
+
+{{- define "common.ingress.annotations" -}}
+{{- $root := .root -}}
+{{- $ingress := .ingress | default dict -}}
+{{- $annotations := dict -}}
+{{- if $root.Values.tls.enabled -}}
+{{- if $root.Values.ingress.certificateIssuer.enabled -}}
+{{- $_ := set $annotations "cert-manager.io/issuer" ($root.Values.ingress.certificateIssuer.name | toString) -}}
+{{- else if $root.Values.ingress.issuer -}}
+{{- $_ := set $annotations "cert-manager.io/issuer" ($root.Values.ingress.issuer | toString) -}}
+{{- else if $root.Values.ingress.clusterIssuer -}}
+{{- $_ := set $annotations "cert-manager.io/cluster-issuer" ($root.Values.ingress.clusterIssuer | toString) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $value := ($root.Values.ingress.annotations | default dict) -}}
+{{- if kindIs "invalid" $value -}}
+{{- $_ := unset $annotations $key -}}
+{{- else -}}
+{{- $_ := set $annotations $key (tpl (print $value) $root) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $value := ($ingress.annotations | default dict) -}}
+{{- if kindIs "invalid" $value -}}
+{{- $_ := unset $annotations $key -}}
+{{- else -}}
+{{- $_ := set $annotations $key (tpl (print $value) $root) -}}
+{{- end -}}
+{{- end -}}
+{{- if $annotations -}}
+{{- toYaml $annotations -}}
+{{- end -}}
+{{- end }}
+
+{{- define "common.ingress.metadataAnnotations" -}}
+{{- $annotations := include "common.ingress.annotations" . -}}
+{{- if $annotations }}
+annotations:
+{{ $annotations | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/basyx/templates/aas-discovery/ingress.yaml
+++ b/charts/basyx/templates/aas-discovery/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-aasDiscovery.fullname" . }}
   labels:
     {{- include "basyx-aasDiscovery.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.aasDiscovery.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.aasDiscovery.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.aasDiscovery.ingress.className | quote }}
-  {{- include "common.ingressTLS" . | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.aasDiscovery.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.aasDiscovery.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/aas-environment/ingress.yaml
+++ b/charts/basyx/templates/aas-environment/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-aasEnvironment.fullname" . }}
   labels:
     {{- include "basyx-aasEnvironment.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.aasEnvironment.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.aasEnvironment.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.aasEnvironment.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.aasEnvironment.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.aasEnvironment.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/aas-registry/ingress.yaml
+++ b/charts/basyx/templates/aas-registry/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-aasRegistry.fullname" . }}
   labels:
     {{- include "basyx-aasRegistry.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.aasRegistry.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.aasRegistry.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.aasRegistry.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.aasRegistry.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.aasRegistry.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/aas-repository/ingress.yaml
+++ b/charts/basyx/templates/aas-repository/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-aasRepository.fullname" . }}
   labels:
     {{- include "basyx-aasRepository.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.aasRepository.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.aasRepository.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.aasRepository.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.aasRepository.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.aasRepository.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/aas-web-gui/ingress.yaml
+++ b/charts/basyx/templates/aas-web-gui/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-aasWebGui.fullname" . }}
   labels:
     {{- include "basyx-aasWebGui.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.aasWebGui.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.aasWebGui.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.aasWebGui.ingress.className | quote }}
-  {{ include "common.ingressTLS" . | nindent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.aasWebGui.ingress) | nindent 2 }}
+  {{ include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.aasWebGui.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/cd-repository/ingress.yaml
+++ b/charts/basyx/templates/cd-repository/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-cdRepository.fullname" . }}
   labels:
     {{- include "basyx-cdRepository.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.cdRepository.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.cdRepository.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.cdRepository.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.cdRepository.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.cdRepository.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/company-lookup/ingress.yaml
+++ b/charts/basyx/templates/company-lookup/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-companyLookup.fullname" . }}
   labels:
     {{- include "basyx-companyLookup.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.companyLookup.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.companyLookup.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.companyLookup.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.companyLookup.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.companyLookup.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/digital-twin-registry/ingress.yaml
+++ b/charts/basyx/templates/digital-twin-registry/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-digitalTwinRegistry.fullname" . }}
   labels:
     {{- include "basyx-digitalTwinRegistry.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.digitalTwinRegistry.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.digitalTwinRegistry.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.digitalTwinRegistry.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.digitalTwinRegistry.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.digitalTwinRegistry.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/dpp-api/ingress.yaml
+++ b/charts/basyx/templates/dpp-api/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-dppApi.fullname" . }}
   labels:
     {{- include "basyx-dppApi.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.dppApi.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.dppApi.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.dppApi.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.dppApi.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.dppApi.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/keycloak/ingress.yaml
+++ b/charts/basyx/templates/keycloak/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-keycloak.fullname" . }}
   labels:
     {{- include "basyx-keycloak.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.keycloak.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.keycloak.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.keycloak.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.keycloak.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.keycloak.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/submodel-registry/ingress.yaml
+++ b/charts/basyx/templates/submodel-registry/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-submodelRegistry.fullname" . }}
   labels:
     {{- include "basyx-submodelRegistry.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.submodelRegistry.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.submodelRegistry.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.submodelRegistry.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.submodelRegistry.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.submodelRegistry.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/templates/submodel-repository/ingress.yaml
+++ b/charts/basyx/templates/submodel-repository/ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   name: {{ include "basyx-submodelRepository.fullname" . }}
   labels:
     {{- include "basyx-submodelRepository.labels" . | nindent 4 }}
-  annotations: &commonIngressAnnotations
-  {{- include "common.ingressTLS.annotations" . | nindent 2}}
-  {{- with .Values.submodelRepository.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "common.ingress.metadataAnnotations" (dict "root" . "ingress" .Values.submodelRepository.ingress) | nindent 2 }}
 spec:
-  ingressClassName: {{ .Values.submodelRepository.ingress.className | quote }}
-  {{- include "common.ingressTLS" .  | indent 2}}
+  {{- include "common.ingress.className" (dict "root" . "ingress" .Values.submodelRepository.ingress) | nindent 2 }}
+  {{- include "common.ingressTLS" . | nindent 2 }}
   rules:
     {{- range .Values.submodelRepository.ingress.hosts }}
     - host: {{ tpl .host $ | quote }}

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -10,6 +10,7 @@ templates:
   - templates/aas-web-gui/deployment.yaml
   - templates/aas-discovery/deployment.yaml
   - templates/aas-discovery/ingress.yaml
+  - templates/aas-registry/ingress.yaml
   - templates/aas-environment/ingress.yaml
   - templates/dpp-api/ingress.yaml
   - templates/company-lookup/ingress.yaml
@@ -449,6 +450,50 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: basyx-tls-secret
+
+  - it: renders global ingress defaults for backend services
+    template: templates/aas-registry/ingress.yaml
+    set:
+      aasRegistry.enabled: true
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: "0"
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: basyx.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: basyx-tls-secret
+
+  - it: renders Azure Application Gateway ingress settings from global ingress values
+    template: templates/aas-registry/ingress.yaml
+    values:
+      - fixtures/azure_application_gateway_ingress.yaml
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: azure-application-gateway
+      - equal:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
+          value: azure/application-gateway
+      - equal:
+          path: metadata.annotations["appgw.ingress.kubernetes.io/ssl-redirect"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: agic.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: tls-secret
 
   - it: renders the company lookup ingress with its own path and port
     template: templates/company-lookup/ingress.yaml

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -477,9 +477,8 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: azure-application-gateway
-      - equal:
+      - notExists:
           path: metadata.annotations["kubernetes.io/ingress.class"]
-          value: azure/application-gateway
       - equal:
           path: metadata.annotations["appgw.ingress.kubernetes.io/ssl-redirect"]
           value: "true"

--- a/charts/basyx/tests/config_and_ingress_test.yaml
+++ b/charts/basyx/tests/config_and_ingress_test.yaml
@@ -273,12 +273,6 @@ tests:
       - matchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'baseUrl: https://basyx\.example\.com/submodel-repo'
-      - matchRegex:
-          path: data["basyx-infra.yml"]
-          pattern: 'companyLookup:'
-      - matchRegex:
-          path: data["basyx-infra.yml"]
-          pattern: 'baseUrl: https://basyx\.example\.com/company-lookup'
       - notMatchRegex:
           path: data["basyx-infra.yml"]
           pattern: 'aasRepository:'

--- a/charts/basyx/tests/fixtures/azure_application_gateway_ingress.yaml
+++ b/charts/basyx/tests/fixtures/azure_application_gateway_ingress.yaml
@@ -10,7 +10,6 @@ ingress:
   className: azure-application-gateway
   clusterIssuer: letsencrypt
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: null
 

--- a/charts/basyx/tests/fixtures/azure_application_gateway_ingress.yaml
+++ b/charts/basyx/tests/fixtures/azure_application_gateway_ingress.yaml
@@ -1,0 +1,18 @@
+host: agic.example.com
+
+tls:
+  enabled: true
+  secretName: tls-secret
+  hosts:
+    - "{{ .Values.host }}"
+
+ingress:
+  className: azure-application-gateway
+  clusterIssuer: letsencrypt
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: null
+
+aasRegistry:
+  enabled: true

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -344,9 +344,27 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "secretName": { "type": "string" },
         "hosts": {
           "type": "array",
           "items": { "type": "string" }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "clusterIssuer": { "type": "string" },
+        "issuer": { "type": "string" },
+        "certificateIssuer": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "spec": { "type": "object" }
+          }
         }
       }
     },

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1372,7 +1372,7 @@ aasWebGui:
   image:
     repository: eclipsebasyx/aas-gui
     pullPolicy: Always
-    tag: v2-260721
+    tag: 66ff34d
   imagePullSecrets: []
   nameOverride: "aas-gui"
   fullnameOverride: "aas-gui"

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -26,6 +26,9 @@ tls:
   enabled: true
   hosts:
     - "{{ .Values.host }}"
+  # Optional existing TLS Secret for all generated ingress resources. Defaults
+  # to "<release-name>-tls-secret" when empty.
+  secretName: ""
 
 internal:
   CACertificates:
@@ -54,6 +57,11 @@ internal:
 
 
 ingress:
+  # Global ingress defaults inherited by all service ingress resources. Services
+  # can still override className and annotations under <service>.ingress.
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
   clusterIssuer: ""
   issuer: ""
   certificateIssuer:
@@ -389,7 +397,7 @@ keycloak:
 
   ingress:
     enabled: true
-    className: nginx
+    className: ""
     annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
@@ -476,9 +484,8 @@ submodelRepository:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -567,9 +574,8 @@ submodelRegistry:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -655,9 +661,8 @@ aasRegistry:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -754,9 +759,8 @@ digitalTwinRegistry:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -853,9 +857,8 @@ aasRepository:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -949,9 +952,8 @@ aasEnvironment:
     port: "8082"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -1049,9 +1051,8 @@ dppApi:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -1142,9 +1143,8 @@ cdRepository:
     port: "8080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -1229,9 +1229,8 @@ companyLookup:
     port: "5080"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -1316,9 +1315,8 @@ aasDiscovery:
     port: "8081"
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:
@@ -1449,9 +1447,8 @@ aasWebGui:
 
   ingress:
     enabled: true
-    className: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    className: ""
+    annotations: {}
     hosts:
       - host: "{{ .Values.host }}"
         paths:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -403,7 +403,7 @@ keycloak:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.keycloak }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   resources:
     {}
@@ -490,7 +490,7 @@ submodelRepository:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.submodelRepository }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
   environment:
     # Keep the Submodel Registry in sync when submodels are created, updated or deleted.
     GENERAL_SUBMODELREGISTRYINTEGRATION: true
@@ -580,7 +580,7 @@ submodelRegistry:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.submodelRegistry }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
   environment: {}
   general: {}
   server: {}
@@ -667,7 +667,7 @@ aasRegistry:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.aasRegistry }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
@@ -765,7 +765,7 @@ digitalTwinRegistry:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.digitalTwinRegistry }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
@@ -863,7 +863,7 @@ aasRepository:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.aasRepository }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
@@ -958,7 +958,7 @@ aasEnvironment:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.aasEnvironment }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # AAS Environment bundles the AAS, submodel, concept description, registry
   # and discovery APIs in one service. Preconfigured AAS files can be imported
@@ -1057,7 +1057,7 @@ dppApi:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.dppApi }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # The DPP API composes Digital Product Passport data with the shared BaSyx
   # database. The default history settings mirror the BaSyx DPP API example.
@@ -1149,7 +1149,7 @@ cdRepository:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.cdRepository }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # Content of application.yaml
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
@@ -1235,7 +1235,7 @@ companyLookup:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.companyLookup }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
   environment: {}
   general: {}
   server: {}
@@ -1321,7 +1321,7 @@ aasDiscovery:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.aasDiscovery }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   # central environment variables (will be set in configmap.yaml via tpl interpolation)
   environment: {}
@@ -1453,7 +1453,7 @@ aasWebGui:
       - host: "{{ .Values.host }}"
         paths:
           - path: "{{ .Values.paths.aasWebUi }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
 
   resources: {}
     # limits:

--- a/values/values.catena-x.example.yaml
+++ b/values/values.catena-x.example.yaml
@@ -722,8 +722,6 @@ aasWebGui:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.digitalTwinRegistry }}"
           submodelService:
             baseUrl: "https://{{ .Values.host }}{{ .Values.paths.submodelRepository }}"
-          companyLookup:
-            baseUrl: "https://{{ .Values.host }}{{ .Values.paths.companyLookup }}"
         security:
           type: oauth2
           config:


### PR DESCRIPTION
## Summary

This PR makes the BaSyx Go chart ingress configuration more portable across different Kubernetes ingress controllers.

The chart previously defaulted to nginx-specific assumptions in multiple places. This PR centralizes ingress class and annotation handling and documents how to configure non-nginx controllers such as Azure Application Gateway Ingress Controller (AGIC).

## Changes

- Add global `ingress.className` support for all BaSyx ingress resources.
- Add global `ingress.annotations` support with service-level overrides.
- Allow service-specific ingress settings to override global defaults.
- Allow inherited annotations to be removed by setting them to `null`.
- Add configurable `tls.secretName` for generated ingress TLS blocks.
- Render TLS hosts through `tpl`, allowing values such as `"{{ .Values.host }}"`.
- Update all service ingress templates to use shared ingress helpers.
- Add AGIC example configuration using `spec.ingressClassName: azure-application-gateway`.
- Remove the conflicting legacy `kubernetes.io/ingress.class` annotation from AGIC examples.
- Change default ingress `pathType` values from `ImplementationSpecific` to `Prefix` for better portability.
- Document ingress-controller configuration and path type behavior.
- Extend Helm unittest coverage for generic ingress settings and AGIC rendering.

## Notes

For modern AGIC setups, configure the chart like this:

```yaml
ingress:
  className: azure-application-gateway
  clusterIssuer: letsencrypt
  annotations:
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
    nginx.ingress.kubernetes.io/proxy-body-size: null