### PR TITLE
Adds BaSyx Go observability configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Custom values files live outside the chart, for example:
 values/values.catena-x.example.yaml
 values/values.example.yaml
 values/values.minimal.yaml
+values/values.observability.example.yaml
 values/values.secured.example.yaml
 ```
 
@@ -129,6 +130,9 @@ cp values/values.secured.example.yaml values/values.my-secured-environment.yaml
 
 # Catena-X oriented deployment with marker-based DTR and Submodel access.
 cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yaml
+
+# Optional logging and tracing overlay for an existing Collector.
+cp values/values.observability.example.yaml values/values.my-observability.yaml
 ```
 
 The unsecured example enables the core BaSyx Go services and the Web UI:
@@ -195,6 +199,10 @@ For DPP API deployments, enable `dppApi` in your own values file. DPP commonly r
 
 Use `values/values.catena-x.example.yaml` when you want a Catena-X oriented setup. It enables Keycloak, ABAC, Digital Twin Registry and Submodel Repository with BPN-based marker access rules.
 
+Use `values/values.observability.example.yaml` as an overlay when BaSyx logs
+should use JSON and traces should be exported to an existing OpenTelemetry
+Collector. It does not deploy an observability backend.
+
 Do not publish production passwords or client secrets. For public examples, use placeholders and inject real credentials through your deployment pipeline or an external secret management solution.
 
 ## Render Before Installing
@@ -206,6 +214,7 @@ helm lint charts/basyx -f values/values.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
 helm lint charts/basyx -f values/values.catena-x.example.yaml
+helm lint charts/basyx -f values/values.minimal.yaml -f values/values.observability.example.yaml
 
 helm template basyx charts/basyx \
   -n basyx-custom \
@@ -780,6 +789,80 @@ This applies to:
 - `cdRepository`
 - `companyLookup`
 - `digitalTwinRegistry`
+
+#### Logging, Request Correlation And Tracing
+
+The structured logging and OpenTelemetry values require BaSyx Go `1.0.4` or
+newer.
+
+Logging is configured for every BaSyx Go backend and the Configuration Service:
+
+```yaml
+logging:
+  format: json
+  level: info
+```
+
+BaSyx writes logs to standard error. The chart does not install a log agent or
+send logs directly to Loki. Collect container logs through the cluster logging
+pipeline.
+
+HTTP services automatically return `X-Request-ID` and `X-Correlation-ID` and
+emit one structured access record for each request. No chart value is required
+for request correlation, and these IDs must not be treated as authenticated
+identity data.
+
+Tracing is disabled by default. To send traces to an existing OpenTelemetry
+Collector:
+
+```yaml
+telemetry:
+  tracesExporter: otlp
+  endpoint: http://opentelemetry-collector.observability.svc.cluster.local:4318
+  protocol: http/protobuf
+  existingSecret: ""
+  resourceAttributes: deployment.environment.name=production
+  tracesSampler: parentbased_traceidratio
+  tracesSamplerArg: "0.1"
+  propagators:
+    - tracecontext
+    - baggage
+```
+
+The Configuration Service has no HTTP server and remains logging-only. Advanced
+standard OpenTelemetry settings such as compression, timeouts, batch processor
+limits, and service-specific names can be supplied through
+`environment.common` or a service's `environment` map.
+
+Do not put OTLP authorization headers into a values file. Create a Kubernetes
+Secret containing the standard environment variable and reference it instead:
+
+```bash
+kubectl -n basyx create secret generic basyx-otel-credentials \
+  --from-literal=OTEL_EXPORTER_OTLP_HEADERS='Authorization=Bearer%20<token>'
+```
+
+```yaml
+telemetry:
+  existingSecret: basyx-otel-credentials
+```
+
+Existing Secret changes do not alter the Deployment template automatically.
+Restart the BaSyx backend pods after rotating telemetry credentials.
+
+The example overlay can be combined with another values file:
+
+```bash
+helm upgrade --install basyx charts/basyx \
+  -n basyx \
+  -f values/values.minimal.yaml \
+  -f values/values.observability.example.yaml
+```
+
+This overlay connects BaSyx services to an existing Collector. The chart
+intentionally does not deploy Grafana, Loki, Tempo, Jaeger, Alloy, or the
+Collector because their authentication, storage, retention, tenancy, and
+resource requirements are cluster-specific.
 
 Global runtime defaults:
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.3.1
-appVersion: "1.0.3"
+version: 3.4.0
+appVersion: "1.0.4"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -160,6 +160,8 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- define "basyx.commonConfig.runtimeEnv" -}}
 {{- $root := . -}}
 {{- $common := .Values.environment.common | default dict -}}
+{{- $logging := .Values.logging | default dict -}}
+{{- $telemetry := .Values.telemetry | default dict -}}
 {{- $general := .Values.general | default dict -}}
 {{- $server := .Values.server | default dict -}}
 {{- $history := .Values.history | default dict -}}
@@ -168,6 +170,15 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- $integrityAnchor := dig "integrityAnchor" (dict) $history -}}
 {{- $eventing := .Values.eventing | default dict -}}
 {{- $abac := .Values.abac | default dict -}}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "LOGGING_FORMAT" "value" (dig "format" "text" $logging)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "LOGGING_LEVEL" "value" (dig "level" "info" $logging)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_EXPORTER" "value" (dig "tracesExporter" "none" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_EXPORTER_OTLP_ENDPOINT" "value" (dig "endpoint" "" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_EXPORTER_OTLP_PROTOCOL" "value" (dig "protocol" "http/protobuf" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_RESOURCE_ATTRIBUTES" "value" (dig "resourceAttributes" "" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_SAMPLER" "value" (dig "tracesSampler" "parentbased_always_on" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_SAMPLER_ARG" "value" (dig "tracesSamplerArg" "" $telemetry)) }}
+{{- include "basyx.commonConfig.listEntry" (dict "common" $common "name" "OTEL_PROPAGATORS" "value" (dig "propagators" (list "tracecontext" "baggage") $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_ENABLEIMPLICITCASTS" "value" (dig "enableImplicitCasts" true $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_ENABLEDESCRIPTORDEBUG" "value" (dig "enableDescriptorDebug" false $general)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "GENERAL_DISCOVERYINTEGRATION" "value" (dig "discoveryIntegration" false $general)) }}
@@ -374,6 +385,10 @@ spec:
                 name: {{ include .fullnameHelper $root }}-config
             - secretRef:
                 name: {{ include "basyx.fullname" $root }}-common-config
+            {{- with $root.Values.telemetry.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           resources:
             {{- toYaml $values.resources | nindent 12 }}
           {{- with $values.livenessProbe }}

--- a/charts/basyx/templates/configuration-service-job.yaml
+++ b/charts/basyx/templates/configuration-service-job.yaml
@@ -83,6 +83,14 @@ spec:
           {{- end }}
           env:
             {{- include "common-database-config" . | nindent 12 }}
+            {{- if not (hasKey (.Values.environment.common | default dict) "LOGGING_FORMAT") }}
+            - name: LOGGING_FORMAT
+              value: {{ .Values.logging.format | quote }}
+            {{- end }}
+            {{- if not (hasKey (.Values.environment.common | default dict) "LOGGING_LEVEL") }}
+            - name: LOGGING_LEVEL
+              value: {{ .Values.logging.level | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.environment.common }}
             - name: {{ $key }}
               value: {{ tpl (print $value) $ | quote }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -20,6 +20,7 @@ The suites cover stable chart contracts such as:
 - optional DPP API deployment, ingress and ABAC wiring
 - Catena-X example values and marker-based ABAC wiring
 - common OIDC and ingress configuration
+- structured logging, optional OTLP tracing and telemetry Secret wiring
 - additional custom CA certificate mounts and trust-store wiring
 - runtime `helm test` hook for custom CA mount checks
 - service account helper behavior

--- a/charts/basyx/tests/fixtures/invalid_logging_format.yaml
+++ b/charts/basyx/tests/fixtures/invalid_logging_format.yaml
@@ -1,0 +1,2 @@
+logging:
+  format: yaml

--- a/charts/basyx/tests/fixtures/invalid_telemetry_exporter.yaml
+++ b/charts/basyx/tests/fixtures/invalid_telemetry_exporter.yaml
@@ -1,0 +1,2 @@
+telemetry:
+  tracesExporter: jaeger

--- a/charts/basyx/tests/fixtures/invalid_telemetry_otlp_endpoint.yaml
+++ b/charts/basyx/tests/fixtures/invalid_telemetry_otlp_endpoint.yaml
@@ -1,0 +1,3 @@
+telemetry:
+  tracesExporter: otlp
+  endpoint: ""

--- a/charts/basyx/tests/observability_config_test.yaml
+++ b/charts/basyx/tests/observability_config_test.yaml
@@ -1,0 +1,146 @@
+suite: observability configuration
+release:
+  name: basyx
+templates:
+  - templates/secret.yaml
+  - templates/configuration-service-job.yaml
+  - templates/aas-environment/deployment.yaml
+tests:
+  - it: renders logging defaults and disabled tracing for backend services
+    template: templates/secret.yaml
+    set:
+      aasEnvironment.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    asserts:
+      - equal:
+          path: stringData.LOGGING_FORMAT
+          value: text
+      - equal:
+          path: stringData.LOGGING_LEVEL
+          value: info
+      - equal:
+          path: stringData.OTEL_TRACES_EXPORTER
+          value: none
+
+  - it: renders an OTLP tracing configuration for backend services
+    template: templates/secret.yaml
+    set:
+      aasEnvironment.enabled: true
+      logging.format: json
+      logging.level: warn
+      telemetry.tracesExporter: otlp
+      telemetry.endpoint: http://collector.observability.svc:4318
+      telemetry.protocol: http/protobuf
+      telemetry.resourceAttributes: deployment.environment.name=test
+      telemetry.tracesSampler: parentbased_traceidratio
+      telemetry.tracesSamplerArg: "0.25"
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    asserts:
+      - equal:
+          path: stringData.LOGGING_FORMAT
+          value: json
+      - equal:
+          path: stringData.LOGGING_LEVEL
+          value: warn
+      - equal:
+          path: stringData.OTEL_TRACES_EXPORTER
+          value: otlp
+      - equal:
+          path: stringData.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://collector.observability.svc:4318
+      - equal:
+          path: stringData.OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+      - equal:
+          path: stringData.OTEL_RESOURCE_ATTRIBUTES
+          value: deployment.environment.name=test
+      - equal:
+          path: stringData.OTEL_TRACES_SAMPLER
+          value: parentbased_traceidratio
+      - equal:
+          path: stringData.OTEL_TRACES_SAMPLER_ARG
+          value: "0.25"
+      - equal:
+          path: stringData.OTEL_PROPAGATORS
+          value: tracecontext,baggage
+
+  - it: lets raw common environment values override observability values
+    template: templates/secret.yaml
+    set:
+      aasEnvironment.enabled: true
+      logging.format: json
+      telemetry.tracesExporter: otlp
+      telemetry.endpoint: http://structured-collector:4318
+      environment.common.LOGGING_FORMAT: text
+      environment.common.OTEL_EXPORTER_OTLP_ENDPOINT: http://raw-collector:4318
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    asserts:
+      - equal:
+          path: stringData.LOGGING_FORMAT
+          value: text
+      - equal:
+          path: stringData.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://raw-collector:4318
+
+  - it: configures logging but not tracing for the configuration service
+    template: templates/configuration-service-job.yaml
+    set:
+      logging.format: json
+      logging.level: error
+      telemetry.tracesExporter: otlp
+      telemetry.endpoint: http://collector.observability.svc:4318
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGGING_FORMAT
+            value: json
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGGING_LEVEL
+            value: error
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_EXPORTER
+            value: otlp
+
+  - it: mounts an existing telemetry environment secret in backend services
+    template: templates/aas-environment/deployment.yaml
+    set:
+      aasEnvironment.enabled: true
+      telemetry.existingSecret: basyx-otel-credentials
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: basyx-otel-credentials
+          count: 1
+
+  - it: lets the common environment override configuration service logging
+    template: templates/configuration-service-job.yaml
+    set:
+      logging.format: json
+      environment.common.LOGGING_FORMAT: text
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGGING_FORMAT
+            value: text
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGGING_FORMAT
+            value: json

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -100,6 +100,27 @@ tests:
       - failedTemplate:
           errorPattern: "aasRepository.server.shutdownTimeoutSeconds"
 
+  - it: fails when the logging format is unsupported
+    values:
+      - fixtures/invalid_logging_format.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "logging.format"
+
+  - it: fails when the tracing exporter is unsupported
+    values:
+      - fixtures/invalid_telemetry_exporter.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.tracesExporter"
+
+  - it: fails when OTLP tracing has no Collector endpoint
+    values:
+      - fixtures/invalid_telemetry_otlp_endpoint.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.endpoint"
+
   - it: fails when external database has no existing secret
     values:
       - fixtures/invalid_external_database_missing_secret.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -231,6 +231,83 @@
         }
       }
     },
+    "logging": {
+      "type": "object",
+      "required": ["format", "level"],
+      "properties": {
+        "format": { "type": "string", "enum": ["text", "json"] },
+        "level": { "type": "string", "enum": ["debug", "info", "warn", "error"] }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "required": [
+        "tracesExporter",
+        "endpoint",
+        "protocol",
+        "existingSecret",
+        "resourceAttributes",
+        "tracesSampler",
+        "tracesSamplerArg",
+        "propagators"
+      ],
+      "properties": {
+        "tracesExporter": { "type": "string", "enum": ["none", "otlp", "console"] },
+        "endpoint": { "type": "string" },
+        "protocol": { "type": "string", "enum": ["grpc", "http/protobuf"] },
+        "existingSecret": { "type": "string" },
+        "resourceAttributes": { "type": "string" },
+        "tracesSampler": {
+          "type": "string",
+          "enum": [
+            "always_on",
+            "always_off",
+            "traceidratio",
+            "parentbased_always_on",
+            "parentbased_always_off",
+            "parentbased_traceidratio"
+          ]
+        },
+        "tracesSamplerArg": {
+          "oneOf": [
+            { "type": "string", "pattern": "^$|^(0(\\.[0-9]+)?|1(\\.0+)?)$" },
+            { "type": "number", "minimum": 0, "maximum": 1 }
+          ]
+        },
+        "propagators": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "enum": ["tracecontext", "baggage", "none"] }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "tracesExporter": { "const": "otlp" }
+            },
+            "required": ["tracesExporter"]
+          },
+          "then": {
+            "properties": {
+              "endpoint": { "minLength": 1 }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "propagators": {
+                "minItems": 2,
+                "contains": { "const": "none" }
+              }
+            },
+            "required": ["propagators"]
+          }
+        }
+      ]
+    },
     "keycloak": {
       "type": "object",
       "required": [

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -101,6 +101,29 @@ environment:
     OIDC_AUDIENCE: discovery-service
     ABAC_ENABLED: false
 
+# Structured logging for all BaSyx Go services, including the Configuration
+# Service job. JSON is recommended when logs are collected by a cluster agent.
+logging:
+  format: text
+  level: info
+
+# Optional OpenTelemetry tracing for BaSyx Go HTTP services. The chart connects
+# applications to an existing Collector; it does not deploy an observability
+# backend. Explicit keys in environment.common override these values.
+telemetry:
+  tracesExporter: none
+  endpoint: ""
+  protocol: http/protobuf
+  # Optional existing Secret containing additional standard OTEL_* variables,
+  # for example OTEL_EXPORTER_OTLP_HEADERS. Restart pods after changing it.
+  existingSecret: ""
+  resourceAttributes: ""
+  tracesSampler: parentbased_always_on
+  tracesSamplerArg: ""
+  propagators:
+    - tracecontext
+    - baggage
+
 # Shared BaSyx Go runtime configuration rendered into the common environment
 # for backend services. Explicit keys in environment.common override these
 # structured values.

--- a/values/values.observability.example.yaml
+++ b/values/values.observability.example.yaml
@@ -1,0 +1,28 @@
+# Observability overlay for BaSyx Go 1.0.4 and newer.
+#
+# Apply this file together with a deployment values file, for example:
+#
+#   helm upgrade --install basyx charts/basyx \
+#     -n basyx \
+#     -f values/values.minimal.yaml \
+#     -f values/values.observability.example.yaml
+#
+# This overlay expects an OpenTelemetry Collector to be reachable at the
+# configured endpoint. It does not install the Collector, Tempo, Loki, Grafana,
+# or a log collector.
+
+logging:
+  format: json
+  level: info
+
+telemetry:
+  tracesExporter: otlp
+  endpoint: http://opentelemetry-collector.observability.svc.cluster.local:4318
+  protocol: http/protobuf
+  existingSecret: ""
+  resourceAttributes: deployment.environment.name=kubernetes
+  tracesSampler: parentbased_traceidratio
+  tracesSamplerArg: "0.1"
+  propagators:
+    - tracecontext
+    - baggage


### PR DESCRIPTION
## Summary

- set the chart version to 3.4.0 and BaSyx Go app version to 1.0.4
- add shared text or JSON logging configuration for all BaSyx Go workloads
- add optional OTLP tracing configuration for all BaSyx Go HTTP services
- support an existing Secret for OTLP authorization headers
- document automatic request and correlation IDs
- add a small observability overlay for connecting to an existing Collector
- keep Grafana, Loki, Tempo, Alloy, and the Collector outside the application chart

## Context

This covers the deployment configuration introduced by:

- [basyx-go-components #517](https://github.com/eclipse-basyx/basyx-go-components/pull/517)
- [basyx-go-components #518](https://github.com/eclipse-basyx/basyx-go-components/pull/518)
- [basyx-go-components #519](https://github.com/eclipse-basyx/basyx-go-components/pull/519)

## Release dependency

The BaSyx Go 1.0.4 images must be published before this PR is merged. The chart install check may fail until those images are available.

## Validation

- `helm lint charts/basyx`
- `helm template basyx charts/basyx -f values/values.minimal.yaml -f values/values.observability.example.yaml`
- `helm unittest charts/basyx` (102 tests)
- JSON schema and YAML parsing
- `git diff --check`
