### PR TITLE
fix: allow public access to BaSyx description endpoints

### DIFF
--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.3.1
+version: 3.3.2
 appVersion: "1.0.3"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/tests/abac_config_test.yaml
+++ b/charts/basyx/tests/abac_config_test.yaml
@@ -25,7 +25,22 @@ tests:
           pattern: '"name": "admin_full"'
       - matchRegex:
           path: data["access-rules.json"]
+          pattern: '"name": "anonymous_attr"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"name": "anonymous_read"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"name": "public_description"'
+      - matchRegex:
+          path: data["access-rules.json"]
           pattern: '"name": "all_api"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/description"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"ROUTE": "/aas-registry/description"'
       - matchRegex:
           path: data["access-rules.json"]
           pattern: '"ROUTE": "/concept-descriptions/\*"'
@@ -41,6 +56,9 @@ tests:
       - matchRegex:
           path: data["access-rules.json"]
           pattern: '"USEFORMULA": "is_admin"'
+      - matchRegex:
+          path: data["access-rules.json"]
+          pattern: '"USEOBJECTS": \["public_description"\]'
 
   - it: prefers service-local ABAC overrides over global defaults
     values:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1605,13 +1605,27 @@ abac:
     {
       "AllAccessPermissionRules": {
         "DEFATTRIBUTES": [
+          { "name": "anonymous_attr", "attributes": [{ "GLOBAL": "ANONYMOUS" }] },
           { "name": "role_attr", "attributes": [{ "CLAIM": "role" }] }
         ],
         "DEFOBJECTS": [
           {
-            "name": "all_api",
+            "name": "public_description",
             "objects": [
               { "ROUTE": "/description" },
+              { "ROUTE": "{{ .Values.paths.aasRegistry }}/description" },
+              { "ROUTE": "{{ .Values.paths.submodelRegistry }}/description" },
+              { "ROUTE": "{{ .Values.paths.aasDiscovery }}/description" },
+              { "ROUTE": "{{ .Values.paths.aasRepository }}/description" },
+              { "ROUTE": "{{ .Values.paths.submodelRepository }}/description" },
+              { "ROUTE": "{{ .Values.paths.cdRepository }}/description" },
+              { "ROUTE": "{{ .Values.paths.companyLookup }}/description" },
+              { "ROUTE": "{{ .Values.paths.dppApi }}/description" }
+            ]
+          },
+          {
+            "name": "all_api",
+            "objects": [
               { "ROUTE": "/shell-descriptors" },
               { "ROUTE": "/shell-descriptors/*" },
               { "ROUTE": "/submodel-descriptors" },
@@ -1631,29 +1645,21 @@ abac:
               { "ROUTE": "/v1/dpps/*" },
               { "ROUTE": "/v1/dppsByProductId/*" },
               { "ROUTE": "/v1/dppsByIdAndDate/*" },
-              { "ROUTE": "{{ .Values.paths.aasRegistry }}/description" },
               { "ROUTE": "{{ .Values.paths.aasRegistry }}/shell-descriptors" },
               { "ROUTE": "{{ .Values.paths.aasRegistry }}/shell-descriptors/*" },
-              { "ROUTE": "{{ .Values.paths.submodelRegistry }}/description" },
               { "ROUTE": "{{ .Values.paths.submodelRegistry }}/submodel-descriptors" },
               { "ROUTE": "{{ .Values.paths.submodelRegistry }}/submodel-descriptors/*" },
-              { "ROUTE": "{{ .Values.paths.aasDiscovery }}/description" },
               { "ROUTE": "{{ .Values.paths.aasDiscovery }}/lookup/shells" },
               { "ROUTE": "{{ .Values.paths.aasDiscovery }}/lookup/shells/*" },
               { "ROUTE": "{{ .Values.paths.aasDiscovery }}/lookup/shellsByAssetLink" },
-              { "ROUTE": "{{ .Values.paths.aasRepository }}/description" },
               { "ROUTE": "{{ .Values.paths.aasRepository }}/shells" },
               { "ROUTE": "{{ .Values.paths.aasRepository }}/shells/*" },
-              { "ROUTE": "{{ .Values.paths.submodelRepository }}/description" },
               { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels" },
               { "ROUTE": "{{ .Values.paths.submodelRepository }}/submodels/*" },
-              { "ROUTE": "{{ .Values.paths.cdRepository }}/description" },
               { "ROUTE": "{{ .Values.paths.cdRepository }}/concept-descriptions" },
               { "ROUTE": "{{ .Values.paths.cdRepository }}/concept-descriptions/*" },
-              { "ROUTE": "{{ .Values.paths.companyLookup }}/description" },
               { "ROUTE": "{{ .Values.paths.companyLookup }}/companies" },
               { "ROUTE": "{{ .Values.paths.companyLookup }}/companies/*" },
-              { "ROUTE": "{{ .Values.paths.dppApi }}/description" },
               { "ROUTE": "{{ .Values.paths.dppApi }}/v1/dpps" },
               { "ROUTE": "{{ .Values.paths.dppApi }}/v1/dpps/*" },
               { "ROUTE": "{{ .Values.paths.dppApi }}/v1/dppsByProductId/*" },
@@ -1662,12 +1668,14 @@ abac:
           }
         ],
         "DEFACLS": [
+          { "name": "anonymous_read", "acl": { "USEATTRIBUTES": "anonymous_attr", "RIGHTS": ["READ"], "ACCESS": "ALLOW" } },
           { "name": "admin_full", "acl": { "USEATTRIBUTES": "role_attr", "RIGHTS": ["ALL"], "ACCESS": "ALLOW" } }
         ],
         "DEFFORMULAS": [
           { "name": "is_admin", "formula": { "$eq": [{ "$attribute": { "CLAIM": "role" } }, { "$strVal": "admin" }] } }
         ],
         "rules": [
+          { "USEACL": "anonymous_read", "USEOBJECTS": ["public_description"], "FORMULA": { "$boolean": true } },
           { "USEACL": "admin_full", "USEOBJECTS": ["all_api"], "USEFORMULA": "is_admin" }
         ]
       }


### PR DESCRIPTION
## Summary

This PR fixes ABAC access for BaSyx Go `/description` endpoints.

The BaSyx Go secured example treats `/description` as a publicly readable endpoint. The chart rules previously grouped these routes with the protected API routes, which could cause `403` responses even for authenticated admin users when clients queried service descriptions without a bearer token.

## Changes

- Add an anonymous ABAC attribute for public endpoint access.
- Add a dedicated `public_description` object group for all BaSyx Go `/description` endpoints.
- Allow anonymous `READ` access to the description endpoint group.
- Keep admin access unchanged for protected API routes.
- Extend Helm unit tests to cover the new description endpoint ABAC rules.