### PR TITLE
fix: add opt-in Argo CD sync ordering for configuration job

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,23 @@ configurationService:
 
 `pre-upgrade` runs schema migrations before updated runtime pods are rolled out. `post-install` is used for fresh installs because the PostgreSQL database must exist before the job can connect.
 
+When the chart is deployed by Argo CD, enable the optional Argo CD sync annotations. Argo CD uses `helm template` and maps Helm hooks into its own sync phases, so the chart can explicitly run the Configuration Service as a `Sync` hook in wave `10` and the runtime Deployments in wave `20`. This lets Argo CD recreate prerequisites such as the ServiceAccount, database resources, and generated PostgreSQL Secret before starting the schema job, while still keeping runtime pods behind the migration. These annotations are disabled by default and are not needed for plain Helm installations.
+
+```yaml
+argocd:
+  enabled: true
+  runtimeSyncWave: "20"
+
+configurationService:
+  hook:
+    argocd:
+      enabled: true
+      hook: Sync
+      syncWave: "10"
+      deletePolicy:
+        - BeforeHookCreation
+```
+
 On fresh installs, PostgreSQL may need some time before it accepts connections. The chart therefore adds a `wait-for-database` init container that polls PostgreSQL with `pg_isready` before starting the Configuration Service. This avoids slow Kubernetes Job backoff loops when the database is simply not ready yet.
 
 After deployment, verify the job and logs with:

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.4.0
+version: 3.5.0
 appVersion: "1.0.4"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -314,6 +314,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include .fullnameHelper $root }}
+  {{- if $root.Values.argocd.enabled }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $root.Values.argocd.runtimeSyncWave | quote }}
+  {{- end }}
   labels:
     {{- include .labelsHelper $root | nindent 4 }}
 spec:

--- a/charts/basyx/templates/aas-web-gui/deployment.yaml
+++ b/charts/basyx/templates/aas-web-gui/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "basyx-aasWebGui.fullname" . }}
+  {{- if .Values.argocd.enabled }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.argocd.runtimeSyncWave | quote }}
+  {{- end }}
   labels:
     {{- include "basyx-aasWebGui.labels" . | nindent 4 }}
 spec:

--- a/charts/basyx/templates/configuration-service-job.yaml
+++ b/charts/basyx/templates/configuration-service-job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.configurationService.enabled -}}
+{{- $hookAnnotations := .Values.configurationService.hook.annotations | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,7 +12,16 @@ metadata:
     helm.sh/hook: {{ join "," .Values.configurationService.hook.events | quote }}
     helm.sh/hook-weight: {{ .Values.configurationService.hook.weight | quote }}
     helm.sh/hook-delete-policy: {{ join "," .Values.configurationService.hook.deletePolicy | quote }}
-    {{- with .Values.configurationService.hook.annotations }}
+    {{- if and .Values.argocd.enabled .Values.configurationService.hook.argocd.enabled (not (hasKey $hookAnnotations "argocd.argoproj.io/hook")) }}
+    argocd.argoproj.io/hook: {{ .Values.configurationService.hook.argocd.hook | quote }}
+    {{- end }}
+    {{- if and .Values.argocd.enabled .Values.configurationService.hook.argocd.enabled (not (hasKey $hookAnnotations "argocd.argoproj.io/sync-wave")) }}
+    argocd.argoproj.io/sync-wave: {{ .Values.configurationService.hook.argocd.syncWave | quote }}
+    {{- end }}
+    {{- if and .Values.argocd.enabled .Values.configurationService.hook.argocd.enabled (not (hasKey $hookAnnotations "argocd.argoproj.io/hook-delete-policy")) }}
+    argocd.argoproj.io/hook-delete-policy: {{ join "," .Values.configurationService.hook.argocd.deletePolicy | quote }}
+    {{- end }}
+    {{- with $hookAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/charts/basyx/templates/keycloak/deployment.yaml
+++ b/charts/basyx/templates/keycloak/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "basyx-keycloak.fullname" . }}
+  {{- if .Values.argocd.enabled }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.argocd.runtimeSyncWave | quote }}
+  {{- end }}
   labels:
     {{- include "basyx-keycloak.labels" . | nindent 4 }}
 spec:

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -16,7 +16,6 @@ tests:
   - it: mounts ABAC config and rollout checksum for aas repository
     template: templates/aas-repository/deployment.yaml
     set:
-      argocd.enabled: true
       aasRepository.enabled: true
       abac.enabled: true
     asserts:

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -7,10 +7,16 @@ templates:
   - templates/dpp-api/deployment.yaml
   - templates/company-lookup/deployment.yaml
   - templates/keycloak/deployment.yaml
+  - templates/aas-web-gui/deployment.yaml
+  - templates/aas-web-gui/configmap.yaml
+  - templates/aas-web-gui/configmap-infrastructure.yaml
+  - templates/aas-web-gui/configmap-logos.yaml
+  - templates/aas-web-gui/secret.yaml
 tests:
   - it: mounts ABAC config and rollout checksum for aas repository
     template: templates/aas-repository/deployment.yaml
     set:
+      argocd.enabled: true
       aasRepository.enabled: true
       abac.enabled: true
     asserts:
@@ -64,6 +70,36 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /aas-repository/health
+
+  - it: renders Argo CD runtime sync wave for shared backend deployments
+    template: templates/aas-repository/deployment.yaml
+    set:
+      argocd.enabled: true
+      aasRepository.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "20"
+
+  - it: renders Argo CD runtime sync wave for keycloak
+    template: templates/keycloak/deployment.yaml
+    set:
+      argocd.enabled: true
+      keycloak.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "20"
+
+  - it: renders Argo CD runtime sync wave for the web UI
+    template: templates/aas-web-gui/deployment.yaml
+    set:
+      argocd.enabled: true
+      aasWebGui.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "20"
 
   - it: renders service-local runtime overrides for shared backend deployments
     template: templates/aas-repository/deployment.yaml

--- a/charts/basyx/tests/configuration_service_test.yaml
+++ b/charts/basyx/tests/configuration_service_test.yaml
@@ -87,3 +87,28 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: does not render Argo CD hook annotations by default
+    template: templates/configuration-service-job.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+      - notExists:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      - notExists:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+
+  - it: renders Argo CD hook annotations when enabled
+    template: templates/configuration-service-job.yaml
+    set:
+      argocd.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: Sync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -546,6 +546,13 @@
         "noProxy": { "type": "string" }
       }
     },
+    "argocd": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "runtimeSyncWave": { "type": "string" }
+      }
+    },
     "configurationService": {
       "type": "object",
       "required": ["enabled", "image", "hook", "backoffLimit", "restartPolicy"],
@@ -599,6 +606,26 @@
               "type": "array",
               "minItems": 1,
               "items": { "type": "string", "minLength": 1 }
+            },
+            "argocd": {
+              "type": "object",
+              "required": ["enabled", "hook", "syncWave", "deletePolicy"],
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "hook": {
+                  "type": "string",
+                  "enum": ["PreSync", "Sync", "PostSync", "SyncFail", "Skip"]
+                },
+                "syncWave": { "type": "string" },
+                "deletePolicy": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "enum": ["HookSucceeded", "HookFailed", "BeforeHookCreation"]
+                  }
+                }
+              }
             },
             "annotations": { "type": "object" }
           }

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -204,6 +204,13 @@ proxy:
   https: ""
   noProxy: "localhost,127.0.0.1,.svc.cluster.local"
 
+# Argo CD applies Helm charts with `helm template` and maps Helm hook
+# annotations into its own sync lifecycle. These annotations keep the
+# Configuration Service job after chart prerequisites and before runtime pods.
+argocd:
+  enabled: false
+  runtimeSyncWave: "20"
+
 configurationService:
   # The BaSyx Go Configuration Service initializes and migrates the shared
   # PostgreSQL schema before DB-backed runtime services use it.
@@ -236,6 +243,12 @@ configurationService:
     weight: "-10"
     deletePolicy:
       - before-hook-creation
+    argocd:
+      enabled: true
+      hook: Sync
+      syncWave: "10"
+      deletePolicy:
+        - BeforeHookCreation
     annotations: {}
   backoffLimit: 12
   activeDeadlineSeconds: 900


### PR DESCRIPTION
## Summary

This PR adds optional Argo CD sync ordering for the BaSyx Go Configuration Service job.

The Configuration Service job depends on chart-managed prerequisites such as the shared ServiceAccount and the PostgreSQL application Secret. In Argo CD deployments, Helm hooks are rendered through `helm template` and mapped into Argo CD sync phases. This can make recovery after manually deleted resources fragile, because the Configuration Service hook may start before Argo CD has recreated its prerequisites.

## Changes

- Add optional `argocd.enabled` chart value, disabled by default.
- Render Argo CD hook annotations for the Configuration Service job only when explicitly enabled.
- Run the Configuration Service as an Argo CD `Sync` hook in wave `10`.
- Render runtime Deployment sync-wave annotations in wave `20` when Argo CD support is enabled.
- Keep default Helm rendering unchanged for users who do not use Argo CD.
- Document the optional Argo CD configuration in the README.
- Add Helm unit tests for default behavior and Argo CD opt-in rendering.