### PR TITLE
Expose production PostgreSQL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,73 @@ database:
 
 The values `postgres`, `managed` and `cnpg` all keep this managed database behavior for backwards compatibility.
 
+#### Production CloudNativePG configuration
+
+The chart can select storage classes independently for `PGDATA` and WAL, set PostgreSQL resources and parameters, and pass CloudNativePG scheduling rules through to the managed cluster. Start from [`values/values.postgres-production.example.yaml`](values/values.postgres-production.example.yaml):
+
+```yaml
+database:
+  instances: 3
+  storage:
+    size: 100Gi
+    storageClass: low-latency-block
+  walStorage:
+    enabled: true
+    size: 20Gi
+    storageClass: low-latency-block
+  resources:
+    requests:
+      cpu: "2"
+      memory: 8Gi
+    limits:
+      cpu: "2"
+      memory: 8Gi
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: preferred
+    topologyKey: topology.kubernetes.io/zone
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: basyx-database
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: 2GB
+      effective_cache_size: 6GB
+```
+
+Treat these values as a starting point, not universal production settings. Resource limits, PostgreSQL parameters, volume sizes, and topology rules must match the workload and the available nodes. The example uses equal CPU and memory requests and limits to give the PostgreSQL pods Guaranteed Kubernetes QoS. It uses preferred zone anti-affinity and `ScheduleAnyway` topology spreading so a single-zone or capacity-constrained cluster can still schedule the database. Change either rule to a hard requirement only after verifying that enough eligible zones and nodes always exist.
+
+Benchmark every candidate StorageClass on the target infrastructure before selecting it. CloudNativePG provides an `fio` command for its `kubectl cnpg` plugin. Run destructive storage benchmarks only in staging or pre-production:
+
+```bash
+kubectl cnpg fio basyx-storage-test \
+  --namespace basyx-storage-test \
+  --storageClass low-latency-block \
+  --pvcSize 20Gi
+```
+
+Compare latency, IOPS, throughput, and sustained write behavior with a PostgreSQL-like block size. Also run workload-level tests such as `pgbench` or the BaSyx load test before changing production. See the [CloudNativePG benchmarking guide](https://cloudnative-pg.io/docs/1.30/benchmarking/).
+
+Enabling `database.walStorage.enabled` creates a dedicated WAL PVC for every instance. CloudNativePG does not support removing `walStorage` from an existing cluster after it has been enabled. Decide on the WAL layout before production rollout, include both PGDATA and WAL in capacity monitoring, backup, recovery, and instance-recreation procedures, and always treat an instance's PGDATA and WAL volumes as a pair.
+
+Increasing `storage.size` or `walStorage.size` requires a StorageClass that supports volume expansion. Kubernetes PVCs cannot be shrunk. Changing `storageClass` in values does not migrate existing PVCs to new storage; moving a cluster requires a planned CloudNativePG migration or volume-recreation procedure. Follow the [CloudNativePG 1.30 storage guidance](https://cloudnative-pg.io/docs/1.30/storage/) before changing an existing cluster.
+
+The chart fields in this section are validated against the stable `postgresql.cnpg.io/v1` API documented for CloudNativePG 1.30. Confirm compatibility with the operator version installed in the target cluster during upgrades.
+
+Render and review the production example before installing:
+
+```bash
+helm lint charts/basyx -f values/values.postgres-production.example.yaml
+helm template basyx charts/basyx \
+  -f values/values.postgres-production.example.yaml \
+  > rendered-postgres-production.yaml
+```
+
 #### Existing PostgreSQL Database
 
 To use an existing PostgreSQL database instead of deploying CloudNativePG, set `database.type` to `external`.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,21 @@ helm diff upgrade basyx charts/basyx \
   -f values/values.example.yaml
 ```
 
+### Upgrading to chart 3.6.0
+
+Chart 3.6.0 changes the BaSyx Go per-pod PostgreSQL pool defaults from 500 open and idle connections to 50 open and 25 idle connections. This prevents a small number of replicas from exhausting a typical PostgreSQL connection budget, but workloads that relied on the previous limits can see more request queuing after the upgrade.
+
+Review the aggregate connection budget and load-test the new limits before upgrading. To preserve the previous limits temporarily, set them explicitly:
+
+```yaml
+environment:
+  common:
+    POSTGRES_MAXOPENCONNECTIONS: 500
+    POSTGRES_MAXIDLECONNECTIONS: 500
+```
+
+Only retain those values when PostgreSQL has enough memory and connection capacity for every replica, migration job, identity service, and operational client. Chart 3.6.0 uses BaSyx Go 1.0.5 by default because the idle-time setting and the documented zero-value and validation behavior require that release.
+
 ## Uninstall
 
 Uninstall the Helm release:
@@ -488,9 +503,9 @@ database:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          cnpg.io/cluster: basyx-database
+      labelSelector: {}
+      matchLabelKeys:
+        - cnpg.io/cluster
   postgresql:
     parameters:
       max_connections: "300"
@@ -498,7 +513,15 @@ database:
       effective_cache_size: 6GB
 ```
 
-Treat these values as a starting point, not universal production settings. Resource limits, PostgreSQL parameters, volume sizes, and topology rules must match the workload and the available nodes. The example uses equal CPU and memory requests and limits to give the PostgreSQL pods Guaranteed Kubernetes QoS. It uses preferred zone anti-affinity and `ScheduleAnyway` topology spreading so a single-zone or capacity-constrained cluster can still schedule the database. Change either rule to a hard requirement only after verifying that enough eligible zones and nodes always exist.
+Treat these values as a starting point, not universal production settings. Resource limits, PostgreSQL parameters, volume sizes, and topology rules must match the workload and the available nodes. The example uses equal CPU and memory requests and limits to give the PostgreSQL pods Guaranteed Kubernetes QoS. It uses preferred zone anti-affinity and `ScheduleAnyway` topology spreading so a labeled single-zone or capacity-constrained cluster can still schedule the database. `matchLabelKeys` derives the cluster label value from each incoming CloudNativePG pod instead of duplicating `database.clusterName`.
+
+Before using the zone rules, verify that every eligible database node has a zone label:
+
+```bash
+kubectl get nodes -L topology.kubernetes.io/zone
+```
+
+Nodes without the configured topology key are not eligible for these pods. If the cluster does not use zone labels, change both `database.affinity.topologyKey` and `database.topologySpreadConstraints[].topologyKey` to `kubernetes.io/hostname`, or add consistent zone labels before deployment. Change either scheduling rule to a hard requirement only after verifying that enough eligible zones and nodes always exist.
 
 Benchmark every candidate StorageClass on the target infrastructure before selecting it. CloudNativePG provides an `fio` command for its `kubectl cnpg` plugin. Run destructive storage benchmarks only in staging or pre-production:
 
@@ -511,11 +534,13 @@ kubectl cnpg fio basyx-storage-test \
 
 Compare latency, IOPS, throughput, and sustained write behavior with a PostgreSQL-like block size. Also run workload-level tests such as `pgbench` or the BaSyx load test before changing production. See the [CloudNativePG benchmarking guide](https://cloudnative-pg.io/docs/1.30/benchmarking/).
 
+The example intentionally leaves workload-dependent memory settings such as `work_mem` and `maintenance_work_mem` at their PostgreSQL defaults. `work_mem` can be allocated by several operations in one query and across concurrent connections. Set these parameters only after budgeting shared memory, connection overhead, autovacuum and maintenance memory, per-query memory, and operating-system headroom below the pod memory limit.
+
 Enabling `database.walStorage.enabled` creates a dedicated WAL PVC for every instance. CloudNativePG does not support removing `walStorage` from an existing cluster after it has been enabled. Decide on the WAL layout before production rollout, include both PGDATA and WAL in capacity monitoring, backup, recovery, and instance-recreation procedures, and always treat an instance's PGDATA and WAL volumes as a pair.
 
 Increasing `storage.size` or `walStorage.size` requires a StorageClass that supports volume expansion. Kubernetes PVCs cannot be shrunk. Changing `storageClass` in values does not migrate existing PVCs to new storage; moving a cluster requires a planned CloudNativePG migration or volume-recreation procedure. Follow the [CloudNativePG 1.30 storage guidance](https://cloudnative-pg.io/docs/1.30/storage/) before changing an existing cluster.
 
-The chart fields in this section are validated against the stable `postgresql.cnpg.io/v1` API documented for CloudNativePG 1.30. Confirm compatibility with the operator version installed in the target cluster during upgrades.
+The chart fields in this section, including the nested affinity and label-selector structures, are validated against the stable `postgresql.cnpg.io/v1` API documented for CloudNativePG 1.30. Confirm compatibility with the operator version installed in the target cluster during upgrades.
 
 Render and review the production example before installing:
 
@@ -690,15 +715,25 @@ environment:
 Budget connections before increasing a service's `replicaCount`. For all pods that connect to the same PostgreSQL primary, keep:
 
 ```text
-sum(service replicaCount × POSTGRES_MAXOPENCONNECTIONS)
+sum(BaSyx replicaCount × POSTGRES_MAXOPENCONNECTIONS)
++ Keycloak and other application pools
++ temporary rolling-update pods
 + migration jobs
 + operational connections
 < PostgreSQL max_connections
 ```
 
-Leave capacity for CloudNativePG management, monitoring, migrations, administrators, and failover. For example, six backend pods at the default maximum can request up to 300 connections. If PostgreSQL is configured for 300 connections, the per-pod pool must be reduced because no reserve remains. Set `postgresql.parameters.max_connections` only after checking database memory consumption and workload behavior; raising it is not a substitute for connection budgeting or a pooler.
+Calculate this separately for each PostgreSQL primary. Leave capacity for CloudNativePG management, monitoring, migrations, administrators, failover, and the maximum pod overlap allowed during rolling updates. Keycloak's database pool defaults to 100 connections per pod; when Keycloak shares the database, set an explicit limit under `keycloak.environment.KC_DB_POOL_MAX_SIZE` and include it in the calculation. For example:
 
-`POSTGRES_MAXIDLECONNECTIONS` must not exceed the open limit. With the BaSyx Go pool configuration tracked in [basyx-go-components#535](https://github.com/eclipse-basyx/basyx-go-components/issues/535) and implemented by [PR #537](https://github.com/eclipse-basyx/basyx-go-components/pull/537), zero for max open, max idle, or maximum lifetime selects the application default of 50, 25, or 5 minutes respectively. Zero for `POSTGRES_CONNMAXIDLETIMEMINUTES` has different semantics: it disables recycling based on idle time. Use a BaSyx Go release containing that change before relying on the idle-time setting or these validation rules.
+```yaml
+keycloak:
+  environment:
+    KC_DB_POOL_MAX_SIZE: 20
+```
+
+Six BaSyx backend pods at the default maximum can request up to 300 connections before Keycloak or reserves are included. If PostgreSQL is configured for 300 connections, the per-pod pools must be reduced because no reserve remains. Set `postgresql.parameters.max_connections` only after checking database memory consumption and workload behavior; raising it is not a substitute for connection budgeting or a pooler.
+
+`POSTGRES_MAXIDLECONNECTIONS` must not exceed the open limit. With the BaSyx Go pool configuration tracked in [basyx-go-components#535](https://github.com/eclipse-basyx/basyx-go-components/issues/535) and implemented by [PR #537](https://github.com/eclipse-basyx/basyx-go-components/pull/537), zero for max open, max idle, or maximum lifetime selects the application default of 50, 25, or 5 minutes respectively. When the explicit open limit is below 25 and idle is zero, the effective idle limit is capped to the open limit. Zero for `POSTGRES_CONNMAXIDLETIMEMINUTES` has different semantics: it disables recycling based on idle time. These settings and validation rules require BaSyx Go 1.0.5 or later.
 
 ### BaSyx Configuration Service
 

--- a/README.md
+++ b/README.md
@@ -674,6 +674,32 @@ helm upgrade --install basyx charts/basyx \
 
 When global `database.type: external` is used, the chart does not render a CloudNativePG `Cluster`. The configured external database user must be allowed to create and migrate the BaSyx schema. The `configurationService` still runs by default and initializes or migrates the schema in the existing database. `configurationService.waitForDatabase.enabled: false` only disables the Configuration Service wait initContainer.
 
+#### PostgreSQL connection pool budget
+
+Every BaSyx Go pod owns an independent `database/sql` connection pool. Horizontal scaling therefore multiplies the possible database connections; replicas do not share a pool. The chart uses these common per-pod defaults:
+
+```yaml
+environment:
+  common:
+    POSTGRES_MAXOPENCONNECTIONS: 50
+    POSTGRES_MAXIDLECONNECTIONS: 25
+    POSTGRES_CONNMAXLIFETIMEMINUTES: 5
+    POSTGRES_CONNMAXIDLETIMEMINUTES: 0
+```
+
+Budget connections before increasing a service's `replicaCount`. For all pods that connect to the same PostgreSQL primary, keep:
+
+```text
+sum(service replicaCount × POSTGRES_MAXOPENCONNECTIONS)
++ migration jobs
++ operational connections
+< PostgreSQL max_connections
+```
+
+Leave capacity for CloudNativePG management, monitoring, migrations, administrators, and failover. For example, six backend pods at the default maximum can request up to 300 connections. If PostgreSQL is configured for 300 connections, the per-pod pool must be reduced because no reserve remains. Set `postgresql.parameters.max_connections` only after checking database memory consumption and workload behavior; raising it is not a substitute for connection budgeting or a pooler.
+
+`POSTGRES_MAXIDLECONNECTIONS` must not exceed the open limit. With the BaSyx Go pool configuration tracked in [basyx-go-components#535](https://github.com/eclipse-basyx/basyx-go-components/issues/535) and implemented by [PR #537](https://github.com/eclipse-basyx/basyx-go-components/pull/537), zero for max open, max idle, or maximum lifetime selects the application default of 50, 25, or 5 minutes respectively. Zero for `POSTGRES_CONNMAXIDLETIMEMINUTES` has different semantics: it disables recycling based on idle time. Use a BaSyx Go release containing that change before relying on the idle-time setting or these validation rules.
+
 ### BaSyx Configuration Service
 
 BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same PostgreSQL Secret as the runtime services.

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -6,7 +6,7 @@ description: >
   Keycloak authentication with ABAC authorization.
 type: application
 version: 3.6.0
-appVersion: "1.0.4"
+appVersion: "1.0.5"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.5.0
+version: 3.6.0
 appVersion: "1.0.4"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/postgres.yaml
+++ b/charts/basyx/templates/postgres.yaml
@@ -10,6 +10,33 @@ spec:
   primaryUpdateStrategy: unsupervised
   storage:
     size: {{ .Values.database.storage.size }}
+    {{- with .Values.database.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- if .Values.database.walStorage.enabled }}
+  walStorage:
+    size: {{ .Values.database.walStorage.size }}
+    {{- with .Values.database.walStorage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.database.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.postgresql.parameters }}
+  postgresql:
+    parameters:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
   bootstrap:
     initdb:
       database: {{.Values.database.database | default "basyx" }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -26,4 +26,6 @@ The suites cover stable chart contracts such as:
 - service account helper behavior
 - digest-aware image rendering
 - schema validation for required values and basic formats
+- managed PostgreSQL storage, WAL, resources, scheduling and parameters
+- shared per-pod PostgreSQL pool defaults and Configuration Service propagation
 - keycloak init resources and a runtime `helm test` realm check

--- a/charts/basyx/tests/database_test.yaml
+++ b/charts/basyx/tests/database_test.yaml
@@ -19,6 +19,149 @@ tests:
       - equal:
           path: metadata.name
           value: basyx-database
+      - equal:
+          path: spec.instances
+          value: 3
+      - equal:
+          path: spec.primaryUpdateStrategy
+          value: unsupervised
+      - equal:
+          path: spec.storage.size
+          value: 10Gi
+      - notExists:
+          path: spec.storage.storageClass
+      - notExists:
+          path: spec.walStorage
+      - notExists:
+          path: spec.resources
+      - notExists:
+          path: spec.affinity
+      - notExists:
+          path: spec.topologySpreadConstraints
+      - notExists:
+          path: spec.postgresql
+
+  - it: renders a PGDATA storage class without enabling WAL storage
+    template: templates/postgres.yaml
+    set:
+      database.storage.storageClass: fast-data
+    asserts:
+      - equal:
+          path: spec.storage.storageClass
+          value: fast-data
+      - notExists:
+          path: spec.walStorage
+
+  - it: renders separate WAL storage only when enabled
+    template: templates/postgres.yaml
+    set:
+      database.walStorage.enabled: true
+      database.walStorage.size: 25Gi
+      database.walStorage.storageClass: fast-wal
+    asserts:
+      - equal:
+          path: spec.walStorage
+          value:
+            size: 25Gi
+            storageClass: fast-wal
+
+  - it: renders PostgreSQL resource requests and limits
+    template: templates/postgres.yaml
+    set:
+      database.resources.requests.cpu: 2
+      database.resources.requests.memory: 8Gi
+      database.resources.limits.cpu: 2
+      database.resources.limits.memory: 8Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.cpu
+          value: 2
+      - equal:
+          path: spec.resources.requests.memory
+          value: 8Gi
+      - equal:
+          path: spec.resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.resources.limits.memory
+          value: 8Gi
+
+  - it: renders CloudNativePG affinity and topology scheduling
+    template: templates/postgres.yaml
+    values:
+      - fixtures/database_scheduling.yaml
+    asserts:
+      - equal:
+          path: spec.affinity.nodeSelector.workload
+          value: database
+      - equal:
+          path: spec.affinity.tolerations[0].effect
+          value: NoSchedule
+      - equal:
+          path: spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+
+  - it: renders PostgreSQL parameters as strings
+    template: templates/postgres.yaml
+    set:
+      database.postgresql.parameters.max_connections: "300"
+      database.postgresql.parameters.shared_buffers: 2GB
+    asserts:
+      - equal:
+          path: spec.postgresql.parameters.max_connections
+          value: "300"
+      - equal:
+          path: spec.postgresql.parameters.shared_buffers
+          value: 2GB
+
+  - it: renders production PostgreSQL storage resources and scheduling
+    template: templates/postgres.yaml
+    values:
+      - ../../../values/values.postgres-production.example.yaml
+    asserts:
+      - equal:
+          path: spec.storage
+          value:
+            size: 100Gi
+            storageClass: low-latency-block
+      - equal:
+          path: spec.walStorage
+          value:
+            size: 20Gi
+            storageClass: low-latency-block
+      - equal:
+          path: spec.resources.requests.cpu
+          value: "2"
+      - equal:
+          path: spec.resources.requests.memory
+          value: 8Gi
+      - equal:
+          path: spec.resources.limits.cpu
+          value: "2"
+      - equal:
+          path: spec.resources.limits.memory
+          value: 8Gi
+      - equal:
+          path: spec.affinity.enablePodAntiAffinity
+          value: true
+      - equal:
+          path: spec.affinity.podAntiAffinityType
+          value: preferred
+      - equal:
+          path: spec.affinity.topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - equal:
+          path: spec.postgresql.parameters.max_connections
+          value: "300"
+      - equal:
+          path: spec.postgresql.parameters.shared_buffers
+          value: 2GB
 
   - it: does not render CloudNativePG when an external database is configured
     template: templates/postgres.yaml

--- a/charts/basyx/tests/database_test.yaml
+++ b/charts/basyx/tests/database_test.yaml
@@ -101,6 +101,24 @@ tests:
           path: spec.topologySpreadConstraints[0].whenUnsatisfiable
           value: ScheduleAnyway
 
+  - it: renders nested CloudNativePG affinity structures
+    template: templates/postgres.yaml
+    values:
+      - fixtures/database_advanced_scheduling.yaml
+    asserts:
+      - equal:
+          path: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator
+          value: In
+      - equal:
+          path: spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 50
+      - equal:
+          path: spec.affinity.additionalPodAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.affinity.additionalPodAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: database
+
   - it: renders PostgreSQL parameters as strings
     template: templates/postgres.yaml
     set:
@@ -156,6 +174,13 @@ tests:
       - equal:
           path: spec.topologySpreadConstraints[0].whenUnsatisfiable
           value: ScheduleAnyway
+      - equal:
+          path: spec.topologySpreadConstraints[0].labelSelector
+          value: {}
+      - equal:
+          path: spec.topologySpreadConstraints[0].matchLabelKeys
+          value:
+            - cnpg.io/cluster
       - equal:
           path: spec.postgresql.parameters.max_connections
           value: "300"

--- a/charts/basyx/tests/fixtures/database_advanced_scheduling.yaml
+++ b/charts/basyx/tests/fixtures/database_advanced_scheduling.yaml
@@ -1,0 +1,33 @@
+database:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: workload
+                operator: In
+                values:
+                  - database
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: storage
+                operator: Exists
+    additionalPodAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 25
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/part-of: basyx
+            topologyKey: topology.kubernetes.io/zone
+    additionalPodAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - database
+          topologyKey: kubernetes.io/hostname

--- a/charts/basyx/tests/fixtures/database_scheduling.yaml
+++ b/charts/basyx/tests/fixtures/database_scheduling.yaml
@@ -1,0 +1,16 @@
+database:
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: preferred
+    topologyKey: topology.kubernetes.io/zone
+    nodeSelector:
+      workload: database
+    tolerations:
+      - key: workload
+        operator: Equal
+        value: database
+        effect: NoSchedule
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway

--- a/charts/basyx/tests/fixtures/invalid_database_affinity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_affinity.yaml
@@ -1,0 +1,3 @@
+database:
+  affinity:
+    podAntiAffinityType: mandatory

--- a/charts/basyx/tests/fixtures/invalid_database_match_label_keys.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_match_label_keys.yaml
@@ -1,0 +1,7 @@
+database:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      matchLabelKeys:
+        - pod-template-hash

--- a/charts/basyx/tests/fixtures/invalid_database_min_domains.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_min_domains.yaml
@@ -1,0 +1,6 @@
+database:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      minDomains: 2
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway

--- a/charts/basyx/tests/fixtures/invalid_database_node_affinity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_node_affinity.yaml
@@ -1,0 +1,4 @@
+database:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution: invalid

--- a/charts/basyx/tests/fixtures/invalid_database_parameter.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_parameter.yaml
@@ -1,0 +1,4 @@
+database:
+  postgresql:
+    parameters:
+      max_connections: 300

--- a/charts/basyx/tests/fixtures/invalid_database_pod_affinity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_pod_affinity.yaml
@@ -1,0 +1,4 @@
+database:
+  affinity:
+    additionalPodAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution: invalid

--- a/charts/basyx/tests/fixtures/invalid_database_pod_anti_affinity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_pod_anti_affinity.yaml
@@ -1,0 +1,7 @@
+database:
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 101
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname

--- a/charts/basyx/tests/fixtures/invalid_database_resource_quantity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_resource_quantity.yaml
@@ -1,0 +1,4 @@
+database:
+  resources:
+    requests:
+      cpu: 0.5

--- a/charts/basyx/tests/fixtures/invalid_database_topology_selector.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_topology_selector.yaml
@@ -1,0 +1,8 @@
+database:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: 1

--- a/charts/basyx/tests/fixtures/invalid_database_wal_storage.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_wal_storage.yaml
@@ -1,0 +1,4 @@
+database:
+  walStorage:
+    enabled: true
+    size: ""

--- a/charts/basyx/tests/postgres_pool_config_test.yaml
+++ b/charts/basyx/tests/postgres_pool_config_test.yaml
@@ -1,0 +1,101 @@
+suite: PostgreSQL pool configuration
+release:
+  name: basyx
+templates:
+  - templates/secret.yaml
+  - templates/configuration-service-job.yaml
+tests:
+  - it: renders the common per-pod pool defaults
+    template: templates/secret.yaml
+    set:
+      aasEnvironment.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    asserts:
+      - equal:
+          path: stringData.POSTGRES_MAXOPENCONNECTIONS
+          value: "50"
+      - equal:
+          path: stringData.POSTGRES_MAXIDLECONNECTIONS
+          value: "25"
+      - equal:
+          path: stringData.POSTGRES_CONNMAXLIFETIMEMINUTES
+          value: "5"
+      - equal:
+          path: stringData.POSTGRES_CONNMAXIDLETIMEMINUTES
+          value: "0"
+
+  - it: passes the common pool defaults to the configuration service
+    template: templates/configuration-service-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_MAXOPENCONNECTIONS
+            value: "50"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_MAXIDLECONNECTIONS
+            value: "25"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_CONNMAXLIFETIMEMINUTES
+            value: "5"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_CONNMAXIDLETIMEMINUTES
+            value: "0"
+          count: 1
+
+  - it: propagates pool overrides to both consumers
+    template: templates/secret.yaml
+    set:
+      aasEnvironment.enabled: true
+      environment.common.POSTGRES_MAXOPENCONNECTIONS: 20
+      environment.common.POSTGRES_MAXIDLECONNECTIONS: 10
+      environment.common.POSTGRES_CONNMAXLIFETIMEMINUTES: 30
+      environment.common.POSTGRES_CONNMAXIDLETIMEMINUTES: 10
+    documentSelector:
+      path: metadata.name
+      value: basyx-common-config
+    asserts:
+      - equal:
+          path: stringData.POSTGRES_MAXOPENCONNECTIONS
+          value: "20"
+      - equal:
+          path: stringData.POSTGRES_MAXIDLECONNECTIONS
+          value: "10"
+      - equal:
+          path: stringData.POSTGRES_CONNMAXLIFETIMEMINUTES
+          value: "30"
+      - equal:
+          path: stringData.POSTGRES_CONNMAXIDLETIMEMINUTES
+          value: "10"
+
+  - it: propagates pool overrides to the configuration service
+    template: templates/configuration-service-job.yaml
+    set:
+      environment.common.POSTGRES_MAXOPENCONNECTIONS: 20
+      environment.common.POSTGRES_MAXIDLECONNECTIONS: 10
+      environment.common.POSTGRES_CONNMAXLIFETIMEMINUTES: 30
+      environment.common.POSTGRES_CONNMAXIDLETIMEMINUTES: 10
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_MAXOPENCONNECTIONS
+            value: "20"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_CONNMAXIDLETIMEMINUTES
+            value: "10"
+          count: 1

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -170,6 +170,34 @@ tests:
       - failedTemplate:
           errorPattern: "database.affinity.podAntiAffinityType"
 
+  - it: fails when database node affinity has an invalid structure
+    values:
+      - fixtures/invalid_database_node_affinity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.affinity.nodeAffinity"
+
+  - it: fails when additional database pod affinity has an invalid structure
+    values:
+      - fixtures/invalid_database_pod_affinity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.affinity.additionalPodAffinity"
+
+  - it: fails when additional database pod anti-affinity has an invalid weight
+    values:
+      - fixtures/invalid_database_pod_anti_affinity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.affinity.additionalPodAntiAffinity"
+
+  - it: fails when database topology selector labels are not strings
+    values:
+      - fixtures/invalid_database_topology_selector.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.topologySpreadConstraints"
+
   - it: fails when a PostgreSQL parameter is not a string
     values:
       - fixtures/invalid_database_parameter.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -156,6 +156,48 @@ tests:
       - failedTemplate:
           errorPattern: "database.type"
 
+  - it: fails when enabled WAL storage has no size
+    values:
+      - fixtures/invalid_database_wal_storage.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.walStorage.size"
+
+  - it: fails when database pod anti-affinity type is unsupported
+    values:
+      - fixtures/invalid_database_affinity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.affinity.podAntiAffinityType"
+
+  - it: fails when a PostgreSQL parameter is not a string
+    values:
+      - fixtures/invalid_database_parameter.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.postgresql.parameters.max_connections"
+
+  - it: fails when a database resource quantity is a decimal number
+    values:
+      - fixtures/invalid_database_resource_quantity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.resources.requests.cpu"
+
+  - it: fails when minDomains is used with ScheduleAnyway
+    values:
+      - fixtures/invalid_database_min_domains.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.topologySpreadConstraints"
+
+  - it: fails when matchLabelKeys has no label selector
+    values:
+      - fixtures/invalid_database_match_label_keys.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.topologySpreadConstraints"
+
   - it: fails when ABAC policy scope contains unsupported characters
     values:
       - fixtures/invalid_abac_policy_scope.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -2,6 +2,303 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
+    "labelSelectorRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "operator"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator": {
+          "type": "string",
+          "enum": ["In", "NotIn", "Exists", "DoesNotExist"]
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "operator": {
+                "enum": ["In", "NotIn"]
+              }
+            },
+            "required": ["operator"]
+          },
+          "then": {
+            "required": ["values"],
+            "properties": {
+              "values": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operator": {
+                "enum": ["Exists", "DoesNotExist"]
+              }
+            },
+            "required": ["operator"]
+          },
+          "then": {
+            "properties": {
+              "values": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    "labelSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "matchLabels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "matchExpressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/labelSelectorRequirement"
+          }
+        }
+      }
+    },
+    "nodeSelectorRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "operator"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator": {
+          "type": "string",
+          "enum": ["In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"]
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "operator": {
+                "enum": ["In", "NotIn"]
+              }
+            },
+            "required": ["operator"]
+          },
+          "then": {
+            "required": ["values"],
+            "properties": {
+              "values": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operator": {
+                "enum": ["Exists", "DoesNotExist"]
+              }
+            },
+            "required": ["operator"]
+          },
+          "then": {
+            "properties": {
+              "values": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operator": {
+                "enum": ["Gt", "Lt"]
+              }
+            },
+            "required": ["operator"]
+          },
+          "then": {
+            "required": ["values"],
+            "properties": {
+              "values": {
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nodeSelectorTerm": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "matchExpressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/nodeSelectorRequirement"
+          }
+        },
+        "matchFields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/nodeSelectorRequirement"
+          }
+        }
+      }
+    },
+    "nodeAffinity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["nodeSelectorTerms"],
+          "properties": {
+            "nodeSelectorTerms": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/nodeSelectorTerm"
+              }
+            }
+          }
+        },
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["weight", "preference"],
+            "properties": {
+              "weight": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100
+              },
+              "preference": {
+                "$ref": "#/definitions/nodeSelectorTerm"
+              }
+            }
+          }
+        }
+      }
+    },
+    "podAffinityTerm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topologyKey"],
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/labelSelector"
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/labelSelector"
+        },
+        "namespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topologyKey": {
+          "type": "string",
+          "minLength": 1
+        },
+        "matchLabelKeys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "mismatchLabelKeys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["matchLabelKeys"]
+          },
+          "then": {
+            "required": ["labelSelector"]
+          }
+        },
+        {
+          "if": {
+            "required": ["mismatchLabelKeys"]
+          },
+          "then": {
+            "required": ["labelSelector"]
+          }
+        }
+      ]
+    },
+    "weightedPodAffinityTerm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weight", "podAffinityTerm"],
+      "properties": {
+        "weight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "podAffinityTerm": {
+          "$ref": "#/definitions/podAffinityTerm"
+        }
+      }
+    },
+    "podAffinity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/podAffinityTerm"
+          }
+        },
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/weightedPodAffinityTerm"
+          }
+        }
+      }
+    },
     "serviceRuntimeOverrides": {
       "type": "object",
       "properties": {
@@ -799,7 +1096,7 @@
               }
             },
             "nodeAffinity": {
-              "type": "object"
+              "$ref": "#/definitions/nodeAffinity"
             },
             "tolerations": {
               "type": "array",
@@ -824,10 +1121,10 @@
               }
             },
             "additionalPodAffinity": {
-              "type": "object"
+              "$ref": "#/definitions/podAffinity"
             },
             "additionalPodAntiAffinity": {
-              "type": "object"
+              "$ref": "#/definitions/podAffinity"
             }
           }
         },
@@ -850,7 +1147,7 @@
                 "enum": ["DoNotSchedule", "ScheduleAnyway"]
               },
               "labelSelector": {
-                "type": "object"
+                "$ref": "#/definitions/labelSelector"
               },
               "minDomains": {
                 "type": "integer",

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -734,6 +734,176 @@
             "size": {
               "type": "string",
               "minLength": 1
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "walStorage": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  { "type": "string", "minLength": 1 },
+                  { "type": "integer", "minimum": 0 }
+                ]
+              }
+            },
+            "limits": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  { "type": "string", "minLength": 1 },
+                  { "type": "integer", "minimum": 0 }
+                ]
+              }
+            }
+          }
+        },
+        "affinity": {
+          "type": "object",
+          "properties": {
+            "enablePodAntiAffinity": {
+              "type": "boolean"
+            },
+            "podAntiAffinityType": {
+              "type": "string",
+              "enum": ["preferred", "required"]
+            },
+            "topologyKey": {
+              "type": "string",
+              "minLength": 1
+            },
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "nodeAffinity": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": { "type": "string" },
+                  "operator": {
+                    "type": "string",
+                    "enum": ["Exists", "Equal"]
+                  },
+                  "value": { "type": "string" },
+                  "effect": {
+                    "type": "string",
+                    "enum": ["", "NoSchedule", "PreferNoSchedule", "NoExecute"]
+                  },
+                  "tolerationSeconds": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            },
+            "additionalPodAffinity": {
+              "type": "object"
+            },
+            "additionalPodAntiAffinity": {
+              "type": "object"
+            }
+          }
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+            "properties": {
+              "maxSkew": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "topologyKey": {
+                "type": "string",
+                "minLength": 1
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "enum": ["DoNotSchedule", "ScheduleAnyway"]
+              },
+              "labelSelector": {
+                "type": "object"
+              },
+              "minDomains": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "matchLabelKeys": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "nodeAffinityPolicy": {
+                "type": "string",
+                "enum": ["Honor", "Ignore"]
+              },
+              "nodeTaintsPolicy": {
+                "type": "string",
+                "enum": ["Honor", "Ignore"]
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "required": ["minDomains"]
+                },
+                "then": {
+                  "properties": {
+                    "whenUnsatisfiable": {
+                      "const": "DoNotSchedule"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["matchLabelKeys"]
+                },
+                "then": {
+                  "required": ["labelSelector"]
+                }
+              }
+            ]
+          }
+        },
+        "postgresql": {
+          "type": "object",
+          "properties": {
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         }
@@ -775,6 +945,33 @@
                 "required": ["external"]
               }
             ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "walStorage": {
+                "type": "object",
+                "properties": {
+                  "enabled": { "const": true }
+                },
+                "required": ["enabled"]
+              }
+            },
+            "required": ["walStorage"]
+          },
+          "then": {
+            "properties": {
+              "walStorage": {
+                "required": ["size"],
+                "properties": {
+                  "size": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
           }
         }
       ]

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1602,6 +1602,27 @@ database:
   storage:
     # Volume size per instance
     size: 10Gi
+    # Empty uses the cluster's default StorageClass.
+    storageClass: ""
+  # A separate WAL volume is optional. Once enabled on an existing CloudNativePG
+  # cluster, walStorage cannot be removed again.
+  walStorage:
+    enabled: false
+    size: ""
+    # Empty uses the cluster's default StorageClass.
+    storageClass: ""
+  # PostgreSQL container requests and limits.
+  resources: {}
+  # CloudNativePG affinity configuration. Supported fields include
+  # enablePodAntiAffinity, podAntiAffinityType, topologyKey, nodeSelector,
+  # nodeAffinity, tolerations, additionalPodAffinity and
+  # additionalPodAntiAffinity.
+  affinity: {}
+  # Kubernetes topology spread constraints applied to PostgreSQL pods.
+  topologySpreadConstraints: []
+  # PostgreSQL settings accepted by CloudNativePG. Values must be strings.
+  postgresql:
+    parameters: {}
 
 # PodDisruptionBudget: not managed by this chart. For HA deployments, create
 # PDBs separately to guarantee availability during node drains. Example:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -94,9 +94,13 @@ environment:
     CORS_ALLOWEDHEADERS: "*"
     CORS_ALLOWEDCREDENTIALS: false
     CORS_ALLOWEDMETHODS: GET,POST,PUT,PATCH,DELETE,OPTIONS
-    POSTGRES_MAXOPENCONNECTIONS: 500
-    POSTGRES_MAXIDLECONNECTIONS: 500
+    # PostgreSQL pool limits are per pod and multiply with replicaCount.
+    # Zero for open, idle or lifetime uses the BaSyx Go default. Zero idle time
+    # disables recycling based on idle duration.
+    POSTGRES_MAXOPENCONNECTIONS: 50
+    POSTGRES_MAXIDLECONNECTIONS: 25
     POSTGRES_CONNMAXLIFETIMEMINUTES: 5
+    POSTGRES_CONNMAXIDLETIMEMINUTES: 0
     SERVER_STRICTVERIFICATION: permissive
     OIDC_AUDIENCE: discovery-service
     ABAC_ENABLED: false

--- a/values/values.postgres-production.example.yaml
+++ b/values/values.postgres-production.example.yaml
@@ -1,0 +1,34 @@
+database:
+  instances: 3
+  storage:
+    size: 100Gi
+    storageClass: low-latency-block
+  walStorage:
+    enabled: true
+    size: 20Gi
+    storageClass: low-latency-block
+  resources:
+    requests:
+      cpu: "2"
+      memory: 8Gi
+    limits:
+      cpu: "2"
+      memory: 8Gi
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: preferred
+    topologyKey: topology.kubernetes.io/zone
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: basyx-database
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: 2GB
+      effective_cache_size: 6GB
+      maintenance_work_mem: 512MB
+      work_mem: 8MB

--- a/values/values.postgres-production.example.yaml
+++ b/values/values.postgres-production.example.yaml
@@ -22,13 +22,11 @@ database:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          cnpg.io/cluster: basyx-database
+      labelSelector: {}
+      matchLabelKeys:
+        - cnpg.io/cluster
   postgresql:
     parameters:
       max_connections: "300"
       shared_buffers: 2GB
       effective_cache_size: 6GB
-      maintenance_work_mem: 512MB
-      work_mem: 8MB


### PR DESCRIPTION
This exposes the CloudNativePG settings we need to size and place PostgreSQL independently from the BaSyx services.

Changes:
- add optional PGDATA and WAL storage class configuration
- add PostgreSQL resources, scheduling settings, and parameters
- validate nested node affinity, pod affinity, and label selector values
- keep the default CloudNativePG Cluster spec unchanged when the new settings are not used
- add a production values example with storage benchmarking, scheduling preflight, memory budgeting, and WAL lifecycle guidance
- reduce the common per-pod connection pool defaults to 50 open and 25 idle connections
- pass the pool settings, including max idle time, to the common Secret and Configuration Service job
- document per-primary connection budgeting, Keycloak and rolling-update capacity, zero-value semantics, and the 3.6.0 upgrade impact
- bump the chart version to 3.6.0 and the default BaSyx Go version to 1.0.5

This PR must not be merged until BaSyx Go 1.0.5 is available. The pool idle-time setting and documented zero-value behavior depend on eclipse-basyx/basyx-go-components#535, implemented by merged eclipse-basyx/basyx-go-components#537. The chart install check also requires the 1.0.5 container images and is expected to remain pending or fail until they are published.

Checks:
- `helm unittest charts/basyx` (128 tests)
- `helm lint` with every example values file
- default and production `helm template` renders
- `ct lint` against upstream `main`
- JSON schema syntax validation
- CloudNativePG v1.30 Cluster CRD schema validation for default and production renders
- default Cluster spec comparison against chart 3.5.0
- full wiki Sphinx HTML build in the companion documentation PR

Closes #84
