### PR TITLE
Add a CloudNativePG read-write Pooler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,10 +1020,10 @@ This applies to:
 - `companyLookup`
 - `digitalTwinRegistry`
 
-#### Logging, Request Correlation And Tracing
+#### Logging, Request Correlation And Telemetry
 
-The structured logging and OpenTelemetry values require BaSyx Go `1.0.4` or
-newer.
+Structured logging and tracing require BaSyx Go `1.0.4` or newer. PostgreSQL
+pool metrics require BaSyx Go `1.0.6` or newer.
 
 Logging is configured for every BaSyx Go backend and the Configuration Service:
 
@@ -1042,14 +1042,17 @@ emit one structured access record for each request. No chart value is required
 for request correlation, and these IDs must not be treated as authenticated
 identity data.
 
-Tracing is disabled by default. To send traces to an existing OpenTelemetry
-Collector:
+Tracing and metrics are independently disabled by default. To send both signals
+to an existing OpenTelemetry Collector:
 
 ```yaml
 telemetry:
   tracesExporter: otlp
+  metricsExporter: otlp
   endpoint: http://opentelemetry-collector.observability.svc.cluster.local:4318
   protocol: http/protobuf
+  metricsExportInterval: "60000"
+  metricsExportTimeout: "30000"
   existingSecret: ""
   resourceAttributes: deployment.environment.name=production
   tracesSampler: parentbased_traceidratio
@@ -1059,10 +1062,31 @@ telemetry:
     - baggage
 ```
 
-The Configuration Service has no HTTP server and remains logging-only. Advanced
-standard OpenTelemetry settings such as compression, timeouts, batch processor
-limits, and service-specific names can be supplied through
-`environment.common` or a service's `environment` map.
+`metricsExportInterval` and `metricsExportTimeout` are optional positive
+millisecond values. Leave them empty to use the OpenTelemetry SDK defaults.
+The shared endpoint and protocol apply to traces and metrics. Advanced standard
+settings, including signal-specific endpoints, headers, compression and
+timeouts, can be supplied through `environment.common`,
+`telemetry.existingSecret`, or a service's `environment` map.
+
+BaSyx Go exports the following PostgreSQL writer-pool metrics without executing
+additional database queries:
+
+| Metric | Meaning |
+| --- | --- |
+| `db.client.connection.max` | Configured maximum open connections |
+| `db.client.connection.count` with `state=used` or `state=idle` | Current pool use |
+| `basyx.db.client.connection.waits` | Cumulative waits for a connection |
+| `basyx.db.client.connection.wait_time` | Cumulative wait duration in seconds |
+| `basyx.db.client.connection.closed` with a bounded `reason` | Cumulative closures caused by pool limits |
+
+Use rates for cumulative counters. A rising wait rate while used connections
+approach the maximum points to the BaSyx application pool. When the optional
+CloudNativePG Pooler is enabled, compare these metrics with
+`cnpg_pgbouncer_*` metrics to distinguish waits inside the application from
+PgBouncer queueing.
+
+The Configuration Service has no HTTP server and remains logging-only.
 
 Do not put OTLP authorization headers into a values file. Create a Kubernetes
 Secret containing the standard environment variable and reference it instead:

--- a/README.md
+++ b/README.md
@@ -767,7 +767,9 @@ The Pooler is disabled by default and is rendered only for a managed database.
 When enabled, BaSyx runtime services using the global database connect to
 `<database.clusterName>-rw-pooler`. They reuse the user, password, database and
 port from the CloudNativePG application Secret. Service-specific database
-overrides are not redirected.
+overrides are not redirected. For long cluster names, the chart truncates the
+cluster-name portion of the Pooler service name to keep the generated name
+within 63 characters and distinct from the CloudNativePG Cluster name.
 
 The Configuration Service wait container and migration container always use
 the direct CloudNativePG read-write service from the application Secret.

--- a/README.md
+++ b/README.md
@@ -735,6 +735,91 @@ Six BaSyx backend pods at the default maximum can request up to 300 connections 
 
 `POSTGRES_MAXIDLECONNECTIONS` must not exceed the open limit. With the BaSyx Go pool configuration tracked in [basyx-go-components#535](https://github.com/eclipse-basyx/basyx-go-components/issues/535) and implemented by [PR #537](https://github.com/eclipse-basyx/basyx-go-components/pull/537), zero for max open, max idle, or maximum lifetime selects the application default of 50, 25, or 5 minutes respectively. When the explicit open limit is below 25 and idle is zero, the effective idle limit is capped to the open limit. Zero for `POSTGRES_CONNMAXIDLETIMEMINUTES` has different semantics: it disables recycling based on idle time. These settings and validation rules require BaSyx Go 1.0.5 or later.
 
+#### Optional CloudNativePG read-write Pooler
+
+For a managed CloudNativePG database, the chart can place a PgBouncer access
+layer between BaSyx runtime pods and the PostgreSQL primary:
+
+```yaml
+database:
+  pooler:
+    enabled: true
+    instances: 2
+    poolMode: transaction
+    maxClientConn: 1000
+    defaultPoolSize: 25
+    preparedStatements:
+      enabled: true
+      maxPreparedStatements: 100
+    parameters:
+      reserve_pool_size: "5"
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+```
+
+The Pooler is disabled by default and is rendered only for a managed database.
+When enabled, BaSyx runtime services using the global database connect to
+`<database.clusterName>-rw-pooler`. They reuse the user, password, database and
+port from the CloudNativePG application Secret. Service-specific database
+overrides are not redirected.
+
+The Configuration Service wait container and migration container always use
+the direct CloudNativePG read-write service from the application Secret.
+Migrations use session-level advisory locks and must not run through a
+transaction Pooler. Keycloak also continues to use the direct JDBC URI.
+
+`maxClientConn` is the maximum number of client connections accepted by each
+PgBouncer pod. `defaultPoolSize` is the default number of PostgreSQL server
+connections maintained by each PgBouncer pod for each user/database pair. A
+useful starting budget for the primary is:
+
+```text
+Pooler instances × (defaultPoolSize + reserve_pool_size)
++ direct Keycloak connections
++ migration, monitoring, administration and failover reserve
+< PostgreSQL max_connections
+```
+
+Adjust the formula when multiple user/database pairs use the Pooler or when
+additional PgBouncer limits are configured. The BaSyx per-pod
+`POSTGRES_MAXOPENCONNECTIONS` values still bound client connections into
+PgBouncer. They may collectively exceed the PgBouncer server pool because
+PgBouncer queues work, but they must remain below the aggregate client capacity
+and within acceptable queueing latency:
+
+```text
+sum(BaSyx replicas × POSTGRES_MAXOPENCONNECTIONS)
+< Pooler instances × maxClientConn
+```
+
+A Pooler controls connection concurrency; it does not add write capacity to the
+single PostgreSQL primary. If latency rises while PgBouncer clients wait for
+server connections, first inspect query time, lock contention, storage latency
+and primary CPU before increasing `defaultPoolSize`.
+
+Transaction pooling requires PgBouncer prepared-statement tracking for clients
+that use protocol-level prepared statements. The chart enables
+`max_prepared_statements` with a value of `100` by default when the Pooler is
+enabled. Set `preparedStatements.enabled: false` only for a verified workload
+that does not use them. Additional values under `parameters` must be strings
+and must be supported by the PgBouncer version bundled with the installed
+CloudNativePG operator. The first-class connection limits and prepared
+statement settings take precedence over duplicate parameter keys.
+
+Before production rollout, verify the exact CloudNativePG and PgBouncer
+versions, render the `Pooler` resource, and run the BaSyx integration and load
+tests through the Pooler. Include bulk endpoints, large-object operations,
+rolling updates, primary switchovers and connection saturation. Watch
+`cnpg_pgbouncer_*` metrics together with the BaSyx PostgreSQL pool metrics to
+distinguish application-pool waits from PgBouncer queueing and PostgreSQL
+execution time.
+
 ### BaSyx Configuration Service
 
 BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same PostgreSQL Secret as the runtime services.

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.6.0
-appVersion: "1.0.5"
+version: 3.7.0
+appVersion: "1.0.6"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -791,6 +791,14 @@ Create the name of the service account to use
 {{- if or (eq $type "postgres") (eq $type "managed") (eq $type "cnpg") -}}true{{- else -}}false{{- end -}}
 {{- end}}
 
+{{- define "database.poolerEnabled" -}}
+{{- if and (eq (include "database.managed" .) "true") .Values.database.pooler.enabled -}}true{{- else -}}false{{- end -}}
+{{- end}}
+
+{{- define "database.poolerName" -}}
+{{- printf "%s-rw-pooler" .Values.database.clusterName | trunc 63 | trimSuffix "-" -}}
+{{- end}}
+
 {{/*
 Helper to render TLS block if enabled
 */}}
@@ -971,16 +979,23 @@ annotations:
 {{- end -}}
 {{- $secretContext := dict "root" $root "component" $component "nameSuffix" $nameSuffix -}}
 {{- $databaseSecret := include "database.serviceSecret" $secretContext -}}
+{{- $componentValues := get $root.Values $component | default dict -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- $usePooler := and $component (not $serviceDatabase) (eq (include "database.poolerEnabled" $root) "true") -}}
 - name: POSTGRES_PORT
   valueFrom:
     secretKeyRef:
       name: {{ $databaseSecret }}
       key: port
 - name: POSTGRES_HOST
+  {{- if $usePooler }}
+  value: {{ include "database.poolerName" $root | quote }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: {{ $databaseSecret }}
       key: host
+  {{- end }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -173,8 +173,11 @@ The environment.common map remains the escape hatch and takes precedence.
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "LOGGING_FORMAT" "value" (dig "format" "text" $logging)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "LOGGING_LEVEL" "value" (dig "level" "info" $logging)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_EXPORTER" "value" (dig "tracesExporter" "none" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_METRICS_EXPORTER" "value" (dig "metricsExporter" "none" $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_EXPORTER_OTLP_ENDPOINT" "value" (dig "endpoint" "" $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_EXPORTER_OTLP_PROTOCOL" "value" (dig "protocol" "http/protobuf" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_METRIC_EXPORT_INTERVAL" "value" (dig "metricsExportInterval" "" $telemetry)) }}
+{{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_METRIC_EXPORT_TIMEOUT" "value" (dig "metricsExportTimeout" "" $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_RESOURCE_ATTRIBUTES" "value" (dig "resourceAttributes" "" $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_SAMPLER" "value" (dig "tracesSampler" "parentbased_always_on" $telemetry)) }}
 {{- include "basyx.commonConfig.entry" (dict "root" $root "common" $common "name" "OTEL_TRACES_SAMPLER_ARG" "value" (dig "tracesSamplerArg" "" $telemetry)) }}
@@ -965,7 +968,7 @@ annotations:
 {{- end }}
 
 {{- define "common.config.checksum" -}}
-{{- printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n" (printf "https://%s%s/realms/%s" .Values.host .Values.paths.keycloak .Values.keycloak.realm) (include "common.certs.sslCertDir" .) (toYaml .Values.environment.common) (toYaml .Values.general) (toYaml .Values.history) (toYaml .Values.eventing) (toYaml .Values.abac) | sha256sum -}}
+{{- printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" (printf "https://%s%s/realms/%s" .Values.host .Values.paths.keycloak .Values.keycloak.realm) (include "common.certs.sslCertDir" .) (toYaml .Values.environment.common) (toYaml .Values.logging) (toYaml .Values.telemetry) (toYaml .Values.general) (toYaml .Values.server) (toYaml .Values.history) (toYaml .Values.eventing) (toYaml .Values.abac) | sha256sum -}}
 {{- end }}
 
 {{- define "common-database-config" -}}

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -799,7 +799,12 @@ Create the name of the service account to use
 {{- end}}
 
 {{- define "database.poolerName" -}}
-{{- printf "%s-rw-pooler" .Values.database.clusterName | trunc 63 | trimSuffix "-" -}}
+{{- $clusterName := .Values.database.clusterName -}}
+{{- $poolerName := printf "%s-rw-pooler" ($clusterName | trunc 53 | trimSuffix "-") -}}
+{{- if eq $poolerName $clusterName -}}
+{{- $poolerName = printf "%s-rw-pooler" ($clusterName | trunc 52 | trimSuffix "-") -}}
+{{- end -}}
+{{- $poolerName -}}
 {{- end}}
 
 {{/*

--- a/charts/basyx/templates/postgres-pooler.yaml
+++ b/charts/basyx/templates/postgres-pooler.yaml
@@ -1,0 +1,54 @@
+{{- if eq (include "database.poolerEnabled" .) "true" -}}
+{{- $pooler := .Values.database.pooler -}}
+{{- $parameters := deepCopy ($pooler.parameters | default dict) -}}
+{{- $_ := set $parameters "max_client_conn" ($pooler.maxClientConn | toString) -}}
+{{- $_ := set $parameters "default_pool_size" ($pooler.defaultPoolSize | toString) -}}
+{{- $maxPreparedStatements := "0" -}}
+{{- if $pooler.preparedStatements.enabled -}}
+{{- $maxPreparedStatements = $pooler.preparedStatements.maxPreparedStatements | toString -}}
+{{- end -}}
+{{- $_ := set $parameters "max_prepared_statements" $maxPreparedStatements -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: {{ include "database.poolerName" . }}
+  labels:
+    {{- include "basyx.labels" . | nindent 4 }}
+spec:
+  cluster:
+    name: {{ .Values.database.clusterName }}
+  instances: {{ $pooler.instances }}
+  type: rw
+  pgbouncer:
+    poolMode: {{ $pooler.poolMode }}
+    parameters:
+      {{- toYaml $parameters | nindent 6 }}
+  {{- if or $pooler.resources $pooler.nodeSelector $pooler.affinity $pooler.tolerations $pooler.topologySpreadConstraints }}
+  template:
+    spec:
+      {{- if $pooler.resources }}
+      containers:
+        - name: pgbouncer
+          resources:
+            {{- toYaml $pooler.resources | nindent 12 }}
+      {{- else }}
+      containers: []
+      {{- end }}
+      {{- with $pooler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -20,7 +20,7 @@ The suites cover stable chart contracts such as:
 - optional DPP API deployment, ingress and ABAC wiring
 - Catena-X example values and marker-based ABAC wiring
 - common OIDC and ingress configuration
-- structured logging, optional OTLP tracing and telemetry Secret wiring
+- structured logging, optional OTLP traces and metrics, and telemetry Secret wiring
 - additional custom CA certificate mounts and trust-store wiring
 - runtime `helm test` hook for custom CA mount checks
 - service account helper behavior

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -27,5 +27,6 @@ The suites cover stable chart contracts such as:
 - digest-aware image rendering
 - schema validation for required values and basic formats
 - managed PostgreSQL storage, WAL, resources, scheduling and parameters
+- optional CloudNativePG read-write Pooler rendering and connection routing
 - shared per-pod PostgreSQL pool defaults and Configuration Service propagation
 - keycloak init resources and a runtime `helm test` realm check

--- a/charts/basyx/tests/fixtures/database_pooler_scheduling.yaml
+++ b/charts/basyx/tests/fixtures/database_pooler_scheduling.yaml
@@ -1,0 +1,28 @@
+database:
+  pooler:
+    enabled: true
+    instances: 3
+    poolMode: session
+    maxClientConn: 500
+    defaultPoolSize: 20
+    parameters:
+      reserve_pool_size: "5"
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector:
+      workload: database
+    tolerations:
+      - key: database
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway

--- a/charts/basyx/tests/fixtures/invalid_database_pooler_mode.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_pooler_mode.yaml
@@ -1,0 +1,4 @@
+database:
+  pooler:
+    enabled: true
+    poolMode: statement

--- a/charts/basyx/tests/fixtures/invalid_database_pooler_parameter.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_pooler_parameter.yaml
@@ -1,0 +1,5 @@
+database:
+  pooler:
+    enabled: true
+    parameters:
+      reserve_pool_size: 5

--- a/charts/basyx/tests/fixtures/invalid_database_pooler_topology.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_pooler_topology.yaml
@@ -1,0 +1,8 @@
+database:
+  pooler:
+    enabled: true
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        minDomains: 2

--- a/charts/basyx/tests/fixtures/invalid_telemetry_metrics_exporter.yaml
+++ b/charts/basyx/tests/fixtures/invalid_telemetry_metrics_exporter.yaml
@@ -1,0 +1,2 @@
+telemetry:
+  metricsExporter: prometheus

--- a/charts/basyx/tests/fixtures/invalid_telemetry_metrics_interval.yaml
+++ b/charts/basyx/tests/fixtures/invalid_telemetry_metrics_interval.yaml
@@ -1,0 +1,2 @@
+telemetry:
+  metricsExportInterval: "0"

--- a/charts/basyx/tests/fixtures/invalid_telemetry_metrics_otlp_endpoint.yaml
+++ b/charts/basyx/tests/fixtures/invalid_telemetry_metrics_otlp_endpoint.yaml
@@ -1,0 +1,3 @@
+telemetry:
+  metricsExporter: otlp
+  endpoint: ""

--- a/charts/basyx/tests/observability_config_test.yaml
+++ b/charts/basyx/tests/observability_config_test.yaml
@@ -6,7 +6,7 @@ templates:
   - templates/configuration-service-job.yaml
   - templates/aas-environment/deployment.yaml
 tests:
-  - it: renders logging defaults and disabled tracing for backend services
+  - it: renders logging defaults and disabled telemetry for backend services
     template: templates/secret.yaml
     set:
       aasEnvironment.enabled: true
@@ -23,16 +23,28 @@ tests:
       - equal:
           path: stringData.OTEL_TRACES_EXPORTER
           value: none
+      - equal:
+          path: stringData.OTEL_METRICS_EXPORTER
+          value: none
+      - equal:
+          path: stringData.OTEL_METRIC_EXPORT_INTERVAL
+          value: ""
+      - equal:
+          path: stringData.OTEL_METRIC_EXPORT_TIMEOUT
+          value: ""
 
-  - it: renders an OTLP tracing configuration for backend services
+  - it: renders an OTLP tracing and metrics configuration for backend services
     template: templates/secret.yaml
     set:
       aasEnvironment.enabled: true
       logging.format: json
       logging.level: warn
       telemetry.tracesExporter: otlp
+      telemetry.metricsExporter: otlp
       telemetry.endpoint: http://collector.observability.svc:4318
       telemetry.protocol: http/protobuf
+      telemetry.metricsExportInterval: "60000"
+      telemetry.metricsExportTimeout: "30000"
       telemetry.resourceAttributes: deployment.environment.name=test
       telemetry.tracesSampler: parentbased_traceidratio
       telemetry.tracesSamplerArg: "0.25"
@@ -50,11 +62,20 @@ tests:
           path: stringData.OTEL_TRACES_EXPORTER
           value: otlp
       - equal:
+          path: stringData.OTEL_METRICS_EXPORTER
+          value: otlp
+      - equal:
           path: stringData.OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://collector.observability.svc:4318
       - equal:
           path: stringData.OTEL_EXPORTER_OTLP_PROTOCOL
           value: http/protobuf
+      - equal:
+          path: stringData.OTEL_METRIC_EXPORT_INTERVAL
+          value: "60000"
+      - equal:
+          path: stringData.OTEL_METRIC_EXPORT_TIMEOUT
+          value: "30000"
       - equal:
           path: stringData.OTEL_RESOURCE_ATTRIBUTES
           value: deployment.environment.name=test
@@ -74,9 +95,11 @@ tests:
       aasEnvironment.enabled: true
       logging.format: json
       telemetry.tracesExporter: otlp
+      telemetry.metricsExporter: otlp
       telemetry.endpoint: http://structured-collector:4318
       environment.common.LOGGING_FORMAT: text
       environment.common.OTEL_EXPORTER_OTLP_ENDPOINT: http://raw-collector:4318
+      environment.common.OTEL_METRICS_EXPORTER: console
     documentSelector:
       path: metadata.name
       value: basyx-common-config
@@ -87,13 +110,17 @@ tests:
       - equal:
           path: stringData.OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://raw-collector:4318
+      - equal:
+          path: stringData.OTEL_METRICS_EXPORTER
+          value: console
 
-  - it: configures logging but not tracing for the configuration service
+  - it: configures logging but not telemetry for the configuration service
     template: templates/configuration-service-job.yaml
     set:
       logging.format: json
       logging.level: error
       telemetry.tracesExporter: otlp
+      telemetry.metricsExporter: otlp
       telemetry.endpoint: http://collector.observability.svc:4318
     asserts:
       - contains:
@@ -113,6 +140,11 @@ tests:
           content:
             name: OTEL_TRACES_EXPORTER
             value: otlp
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+            value: otlp
 
   - it: mounts an existing telemetry environment secret in backend services
     template: templates/aas-environment/deployment.yaml
@@ -126,6 +158,16 @@ tests:
             secretRef:
               name: basyx-otel-credentials
           count: 1
+
+  - it: includes structured telemetry in the backend rollout checksum
+    template: templates/aas-environment/deployment.yaml
+    set:
+      aasEnvironment.enabled: true
+      telemetry.metricsExporter: console
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/common-config"]
+          value: 9ffd8d421c6251e793cac77166cc94a2d39b064584c6f17b6aeb36f4fc2eee49
 
   - it: lets the common environment override configuration service logging
     template: templates/configuration-service-job.yaml

--- a/charts/basyx/tests/postgres_pooler_test.yaml
+++ b/charts/basyx/tests/postgres_pooler_test.yaml
@@ -1,0 +1,192 @@
+suite: CloudNativePG read-write Pooler
+release:
+  name: basyx
+templates:
+  - templates/postgres-pooler.yaml
+  - templates/configuration-service-job.yaml
+  - templates/aas-registry/deployment.yaml
+tests:
+  - it: does not render the Pooler by default
+    template: templates/postgres-pooler.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a transaction Pooler with prepared statement support
+    template: templates/postgres-pooler.yaml
+    set:
+      database.pooler.enabled: true
+    asserts:
+      - isKind:
+          of: Pooler
+      - equal:
+          path: apiVersion
+          value: postgresql.cnpg.io/v1
+      - equal:
+          path: metadata.name
+          value: basyx-database-rw-pooler
+      - equal:
+          path: spec.cluster.name
+          value: basyx-database
+      - equal:
+          path: spec.instances
+          value: 2
+      - equal:
+          path: spec.type
+          value: rw
+      - equal:
+          path: spec.pgbouncer.poolMode
+          value: transaction
+      - equal:
+          path: spec.pgbouncer.parameters.max_client_conn
+          value: "1000"
+      - equal:
+          path: spec.pgbouncer.parameters.default_pool_size
+          value: "25"
+      - equal:
+          path: spec.pgbouncer.parameters.max_prepared_statements
+          value: "100"
+      - notExists:
+          path: spec.template
+
+  - it: disables prepared statement tracking explicitly
+    template: templates/postgres-pooler.yaml
+    set:
+      database.pooler.enabled: true
+      database.pooler.preparedStatements.enabled: false
+    asserts:
+      - equal:
+          path: spec.pgbouncer.parameters.max_prepared_statements
+          value: "0"
+
+  - it: renders additional parameters resources and scheduling
+    template: templates/postgres-pooler.yaml
+    values:
+      - fixtures/database_pooler_scheduling.yaml
+    asserts:
+      - equal:
+          path: spec.instances
+          value: 3
+      - equal:
+          path: spec.pgbouncer.poolMode
+          value: session
+      - equal:
+          path: spec.pgbouncer.parameters.reserve_pool_size
+          value: "5"
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: pgbouncer
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.nodeSelector.workload
+          value: database
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: NoSchedule
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+
+  - it: gives first-class connection limits precedence over additional parameters
+    template: templates/postgres-pooler.yaml
+    set:
+      database.pooler.enabled: true
+      database.pooler.maxClientConn: 600
+      database.pooler.defaultPoolSize: 30
+      database.pooler.preparedStatements.maxPreparedStatements: 150
+      database.pooler.parameters.max_client_conn: "10"
+      database.pooler.parameters.default_pool_size: "5"
+      database.pooler.parameters.max_prepared_statements: "1"
+    asserts:
+      - equal:
+          path: spec.pgbouncer.parameters.max_client_conn
+          value: "600"
+      - equal:
+          path: spec.pgbouncer.parameters.default_pool_size
+          value: "30"
+      - equal:
+          path: spec.pgbouncer.parameters.max_prepared_statements
+          value: "150"
+
+  - it: routes BaSyx runtime services through the Pooler with CNPG credentials
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.pooler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            value: basyx-database-rw-pooler
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: password
+          count: 1
+
+  - it: keeps the configuration service on the direct read-write service
+    template: templates/configuration-service-job.yaml
+    set:
+      database.pooler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: host
+          count: 1
+
+  - it: does not render a Pooler for an external database
+    template: templates/postgres-pooler.yaml
+    set:
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+      database.pooler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not redirect service-specific database connections
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.pooler.enabled: true
+      aasRegistry.database.existingSecret: basyx-aas-registry-postgres
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-postgres
+                key: host
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            value: basyx-database-rw-pooler

--- a/charts/basyx/tests/postgres_pooler_test.yaml
+++ b/charts/basyx/tests/postgres_pooler_test.yaml
@@ -49,6 +49,32 @@ tests:
       - notExists:
           path: spec.template
 
+  - it: keeps a maximum-length cluster name distinct from the Pooler name
+    template: templates/postgres-pooler.yaml
+    set:
+      database.clusterName: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      database.pooler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rw-pooler
+      - equal:
+          path: spec.cluster.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  - it: avoids a collision when the cluster name already has the Pooler suffix
+    template: templates/postgres-pooler.yaml
+    set:
+      database.clusterName: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-rw-pooler
+      database.pooler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-rw-pooler
+      - equal:
+          path: spec.cluster.name
+          value: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-rw-pooler
+
   - it: disables prepared statement tracking explicitly
     template: templates/postgres-pooler.yaml
     set:

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -212,6 +212,27 @@ tests:
       - failedTemplate:
           errorPattern: "database.resources.requests.cpu"
 
+  - it: fails when the Pooler mode is unsupported
+    values:
+      - fixtures/invalid_database_pooler_mode.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.pooler.poolMode"
+
+  - it: fails when an additional Pooler parameter is not a string
+    values:
+      - fixtures/invalid_database_pooler_parameter.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.pooler.parameters.reserve_pool_size"
+
+  - it: fails when Pooler minDomains is used with ScheduleAnyway
+    values:
+      - fixtures/invalid_database_pooler_topology.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.pooler.topologySpreadConstraints"
+
   - it: fails when minDomains is used with ScheduleAnyway
     values:
       - fixtures/invalid_database_min_domains.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -114,9 +114,30 @@ tests:
       - failedTemplate:
           errorPattern: "telemetry.tracesExporter"
 
+  - it: fails when the metrics exporter is unsupported
+    values:
+      - fixtures/invalid_telemetry_metrics_exporter.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.metricsExporter"
+
+  - it: fails when the metrics export interval is not positive
+    values:
+      - fixtures/invalid_telemetry_metrics_interval.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.metricsExportInterval"
+
   - it: fails when OTLP tracing has no Collector endpoint
     values:
       - fixtures/invalid_telemetry_otlp_endpoint.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.endpoint"
+
+  - it: fails when OTLP metrics have no Collector endpoint
+    values:
+      - fixtures/invalid_telemetry_metrics_otlp_endpoint.yaml
     asserts:
       - failedTemplate:
           errorPattern: "telemetry.endpoint"

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -299,6 +299,21 @@
         }
       }
     },
+    "podSpecAffinity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nodeAffinity": {
+          "$ref": "#/definitions/nodeAffinity"
+        },
+        "podAffinity": {
+          "$ref": "#/definitions/podAffinity"
+        },
+        "podAntiAffinity": {
+          "$ref": "#/definitions/podAffinity"
+        }
+      }
+    },
     "serviceRuntimeOverrides": {
       "type": "object",
       "properties": {
@@ -1200,6 +1215,186 @@
               "type": "object",
               "additionalProperties": {
                 "type": "string"
+              }
+            }
+          }
+        },
+        "pooler": {
+          "type": "object",
+          "required": [
+            "enabled",
+            "instances",
+            "poolMode",
+            "maxClientConn",
+            "defaultPoolSize",
+            "preparedStatements",
+            "parameters",
+            "resources",
+            "nodeSelector",
+            "affinity",
+            "tolerations",
+            "topologySpreadConstraints"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "instances": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "poolMode": {
+              "type": "string",
+              "enum": ["session", "transaction"]
+            },
+            "maxClientConn": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "defaultPoolSize": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "preparedStatements": {
+              "type": "object",
+              "required": ["enabled", "maxPreparedStatements"],
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxPreparedStatements": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "parameters": {
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^[a-z][a-z0-9_]*$"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "oneOf": [
+                      { "type": "string", "minLength": 1 },
+                      { "type": "integer", "minimum": 0 }
+                    ]
+                  }
+                },
+                "limits": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "oneOf": [
+                      { "type": "string", "minLength": 1 },
+                      { "type": "integer", "minimum": 0 }
+                    ]
+                  }
+                }
+              }
+            },
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "affinity": {
+              "$ref": "#/definitions/podSpecAffinity"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["operator"],
+                "properties": {
+                  "key": { "type": "string" },
+                  "operator": {
+                    "type": "string",
+                    "enum": ["Exists", "Equal"]
+                  },
+                  "value": { "type": "string" },
+                  "effect": {
+                    "type": "string",
+                    "enum": ["", "NoSchedule", "PreferNoSchedule", "NoExecute"]
+                  },
+                  "tolerationSeconds": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            },
+            "topologySpreadConstraints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+                "properties": {
+                  "maxSkew": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "topologyKey": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string",
+                    "enum": ["DoNotSchedule", "ScheduleAnyway"]
+                  },
+                  "labelSelector": {
+                    "$ref": "#/definitions/labelSelector"
+                  },
+                  "minDomains": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "matchLabelKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string",
+                    "enum": ["Honor", "Ignore"]
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string",
+                    "enum": ["Honor", "Ignore"]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "required": ["minDomains"]
+                    },
+                    "then": {
+                      "properties": {
+                        "whenUnsatisfiable": {
+                          "const": "DoNotSchedule"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "required": ["matchLabelKeys"]
+                    },
+                    "then": {
+                      "required": ["labelSelector"]
+                    }
+                  }
+                ]
               }
             }
           }

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -555,8 +555,11 @@
       "type": "object",
       "required": [
         "tracesExporter",
+        "metricsExporter",
         "endpoint",
         "protocol",
+        "metricsExportInterval",
+        "metricsExportTimeout",
         "existingSecret",
         "resourceAttributes",
         "tracesSampler",
@@ -565,8 +568,21 @@
       ],
       "properties": {
         "tracesExporter": { "type": "string", "enum": ["none", "otlp", "console"] },
+        "metricsExporter": { "type": "string", "enum": ["none", "otlp", "console"] },
         "endpoint": { "type": "string" },
         "protocol": { "type": "string", "enum": ["grpc", "http/protobuf"] },
+        "metricsExportInterval": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "string", "pattern": "^$|^[1-9][0-9]*$" }
+          ]
+        },
+        "metricsExportTimeout": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "string", "pattern": "^$|^[1-9][0-9]*$" }
+          ]
+        },
         "existingSecret": { "type": "string" },
         "resourceAttributes": { "type": "string" },
         "tracesSampler": {
@@ -596,10 +612,20 @@
       "allOf": [
         {
           "if": {
-            "properties": {
-              "tracesExporter": { "const": "otlp" }
-            },
-            "required": ["tracesExporter"]
+            "anyOf": [
+              {
+                "properties": {
+                  "tracesExporter": { "const": "otlp" }
+                },
+                "required": ["tracesExporter"]
+              },
+              {
+                "properties": {
+                  "metricsExporter": { "const": "otlp" }
+                },
+                "required": ["metricsExporter"]
+              }
+            ]
           },
           "then": {
             "properties": {

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1627,6 +1627,26 @@ database:
   # PostgreSQL settings accepted by CloudNativePG. Values must be strings.
   postgresql:
     parameters: {}
+  # Optional CloudNativePG read-write Pooler for BaSyx runtime services.
+  # The Configuration Service always connects directly to the primary because
+  # schema migrations use session-level advisory locks.
+  pooler:
+    enabled: false
+    instances: 2
+    poolMode: transaction
+    maxClientConn: 1000
+    defaultPoolSize: 25
+    preparedStatements:
+      enabled: true
+      maxPreparedStatements: 100
+    # Additional CloudNativePG-supported PgBouncer parameters. Values must be
+    # strings. The three settings above take precedence over duplicate keys.
+    parameters: {}
+    resources: {}
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
 
 # PodDisruptionBudget: not managed by this chart. For HA deployments, create
 # PDBs separately to guarantee availability during node drains. Example:

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -111,13 +111,19 @@ logging:
   format: text
   level: info
 
-# Optional OpenTelemetry tracing for BaSyx Go HTTP services. The chart connects
-# applications to an existing Collector; it does not deploy an observability
-# backend. Explicit keys in environment.common override these values.
+# Optional OpenTelemetry traces and metrics for BaSyx Go HTTP services. The
+# chart connects applications to an existing Collector; it does not deploy an
+# observability backend. Explicit keys in environment.common override these
+# values.
 telemetry:
   tracesExporter: none
+  metricsExporter: none
   endpoint: ""
   protocol: http/protobuf
+  # Optional positive millisecond values. Empty uses the OpenTelemetry SDK
+  # defaults.
+  metricsExportInterval: ""
+  metricsExportTimeout: ""
   # Optional existing Secret containing additional standard OTEL_* variables,
   # for example OTEL_EXPORTER_OTLP_HEADERS. Restart pods after changing it.
   existingSecret: ""

--- a/values/values.observability.example.yaml
+++ b/values/values.observability.example.yaml
@@ -1,4 +1,4 @@
-# Observability overlay for BaSyx Go 1.0.4 and newer.
+# Observability overlay for BaSyx Go 1.0.6 and newer.
 #
 # Apply this file together with a deployment values file, for example:
 #
@@ -17,8 +17,11 @@ logging:
 
 telemetry:
   tracesExporter: otlp
+  metricsExporter: otlp
   endpoint: http://opentelemetry-collector.observability.svc.cluster.local:4318
   protocol: http/protobuf
+  metricsExportInterval: "60000"
+  metricsExportTimeout: "30000"
   existingSecret: ""
   resourceAttributes: deployment.environment.name=kubernetes
   tracesSampler: parentbased_traceidratio


### PR DESCRIPTION
## Summary

- add an optional CloudNativePG read-write Pooler for managed PostgreSQL deployments
- route BaSyx runtime services through PgBouncer while keeping schema migrations and service-specific database overrides on their direct connections
- expose connection limits, prepared-statement support, resources, scheduling and additional PgBouncer parameters through schema-validated values
- update the chart to BaSyx Go 1.0.6 and add structured OpenTelemetry metrics exporter, interval and timeout values
- document connection budgeting, routing behavior and the PostgreSQL pool metrics

The Pooler remains disabled by default and is never rendered for an external database.

## Dependencies

[eclipse-basyx/basyx-go-components#538](https://github.com/eclipse-basyx/basyx-go-components/pull/538) is merged and the BaSyx Go 1.0.6 container images are available.

This PR should remain a draft until live CloudNativePG/PgBouncer validation is complete.

## Validation

- helm lint with the default and all documented example values
- helm-unittest: 13 suites, 146 tests
- chart-testing lint, including chart version and schema validation
- rendered Pooler validation against the CloudNativePG 1.27.0 CRD
- default, external-database, runtime-routing, migration-routing, service-override, prepared-statement, resources, scheduling and long-name collision cases

Live CloudNativePG/PgBouncer integration still needs to be verified with the 1.0.6 images, including bulk requests, PostgreSQL large objects, rolling updates and connection saturation.

Closes #85