### PR TITLE
Add CloudNativePG PodMonitor resources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,9 @@ jobs:
             fi
           done
 
+      - name: Lint enabled database monitoring
+        run: helm lint charts/basyx --values charts/basyx/tests/fixtures/database_monitoring.yaml
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -822,6 +822,82 @@ rolling updates, primary switchovers and connection saturation. Watch
 distinguish application-pool waits from PgBouncer queueing and PostgreSQL
 execution time.
 
+#### Database and Pooler PodMonitors
+
+The chart can create Prometheus Operator `PodMonitor` resources for the managed
+CloudNativePG instances and the read-write Pooler. Both are disabled by default,
+and the chart does not install Prometheus Operator or the
+`monitoring.coreos.com` CRDs.
+
+```yaml
+database:
+  monitoring:
+    enabled: true
+    # Add labels required by the Prometheus podMonitorSelector.
+    labels:
+      release: kube-prometheus-stack
+    annotations: {}
+    interval: 30s
+    scrapeTimeout: 10s
+    # Empty selects pods in the Helm release namespace.
+    namespaceSelector: {}
+    relabelings: []
+    metricRelabelings:
+      - sourceLabels:
+          - __name__
+        regex: go_.*
+        action: drop
+  pooler:
+    enabled: true
+    monitoring:
+      enabled: true
+      labels:
+        release: kube-prometheus-stack
+      annotations: {}
+      interval: 30s
+      scrapeTimeout: 10s
+      namespaceSelector: {}
+      relabelings: []
+      metricRelabelings: []
+```
+
+PostgreSQL and Pooler monitoring can be enabled independently. The PostgreSQL
+monitor is rendered only for a managed database. The Pooler monitor is rendered
+only when the managed read-write Pooler is also enabled. Neither monitor is
+rendered for `database.type: external`; monitoring an external database remains
+the responsibility of that database's platform.
+
+The chart selects PostgreSQL pods through `cnpg.io/cluster` and Pooler pods
+through `cnpg.io/poolerName`. Both exporters are scraped through the named
+`metrics` port at `/metrics`. An empty `namespaceSelector` keeps target
+discovery in the PodMonitor's namespace. If `matchNames` or `any` is configured,
+make sure it cannot select an unrelated CloudNativePG resource with the same
+name in another namespace.
+
+Prometheus must be configured to discover `PodMonitor` resources in the Helm
+release namespace and to match the configured metadata `labels`. `annotations`
+are applied to the `PodMonitor` itself. `relabelings` modify discovered targets,
+while `metricRelabelings` modify or discard samples before ingestion. Review
+metric relabeling rules carefully because they can silently remove metrics.
+Prometheus Operator rejects a `scrapeTimeout` greater than the `interval`.
+
+Useful starting points for dashboards and alerts include:
+
+| Area | Metrics |
+| --- | --- |
+| PostgreSQL availability | `cnpg_collector_up`, `cnpg_collector_last_collection_error` |
+| WAL and archiving | `cnpg_collector_pg_wal`, `cnpg_collector_pg_wal_archive_status`, `cnpg_collector_wal_bytes`, `cnpg_collector_wal_write_time`, `cnpg_collector_wal_sync_time` |
+| Replication | `cnpg_pg_replication_lag`, `cnpg_pg_replication_is_wal_receiver_up`, `cnpg_pg_replication_streaming_replicas`, `cnpg_collector_sync_replicas` |
+| Pooler pressure | `cnpg_pgbouncer_pools_cl_active`, `cnpg_pgbouncer_pools_cl_waiting`, `cnpg_pgbouncer_pools_maxwait` |
+| Pooler server use | `cnpg_pgbouncer_pools_sv_active`, `cnpg_pgbouncer_pools_sv_idle` |
+| Pooler throughput and waits | `cnpg_pgbouncer_stats_total_query_count`, `cnpg_pgbouncer_stats_total_xact_count`, `cnpg_pgbouncer_stats_total_wait_time` |
+
+Some PostgreSQL query metrics depend on the default monitoring queries shipped
+with the installed CloudNativePG version. For storage capacity and latency,
+combine these database metrics with Kubernetes PVC and node/storage metrics
+such as `kubelet_volume_stats_available_bytes`; those are not emitted by the
+CloudNativePG PodMonitor.
+
 ### BaSyx Configuration Service
 
 BaSyx Go requires the database schema to be prepared before DB-backed services start. The chart enables `configurationService` by default for this. It renders a Kubernetes `Job` using `eclipsebasyx/basyxconfigurationservice-go` and the same PostgreSQL Secret as the runtime services.

--- a/README.md
+++ b/README.md
@@ -886,8 +886,10 @@ Useful starting points for dashboards and alerts include:
 | Area | Metrics |
 | --- | --- |
 | PostgreSQL availability | `cnpg_collector_up`, `cnpg_collector_last_collection_error` |
+| PostgreSQL connection pressure | `cnpg_backends_total`, `cnpg_backends_waiting_total`, `cnpg_backends_max_tx_duration_seconds` |
 | WAL and archiving | `cnpg_collector_pg_wal`, `cnpg_collector_pg_wal_archive_status`, `cnpg_collector_wal_bytes`, `cnpg_collector_wal_write_time`, `cnpg_collector_wal_sync_time` |
 | Replication | `cnpg_pg_replication_lag`, `cnpg_pg_replication_is_wal_receiver_up`, `cnpg_pg_replication_streaming_replicas`, `cnpg_collector_sync_replicas` |
+| Database size | `cnpg_pg_database_size_bytes` |
 | Pooler pressure | `cnpg_pgbouncer_pools_cl_active`, `cnpg_pgbouncer_pools_cl_waiting`, `cnpg_pgbouncer_pools_maxwait` |
 | Pooler server use | `cnpg_pgbouncer_pools_sv_active`, `cnpg_pgbouncer_pools_sv_idle` |
 | Pooler throughput and waits | `cnpg_pgbouncer_stats_total_query_count`, `cnpg_pgbouncer_stats_total_xact_count`, `cnpg_pgbouncer_stats_total_wait_time` |

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.7.0
+version: 3.8.0
 appVersion: "1.0.6"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -807,6 +807,43 @@ Create the name of the service account to use
 {{- $poolerName -}}
 {{- end}}
 
+{{- define "database.podMonitor" -}}
+{{- $root := .root -}}
+{{- $monitor := .monitor -}}
+{{- $labels := mergeOverwrite (include "basyx.labels" $root | fromYaml) ($monitor.labels | default dict) -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- toYaml $labels | nindent 4 }}
+  {{- with $monitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $monitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{ .selectorKey | quote }}: {{ .selectorValue | quote }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ $monitor.interval | quote }}
+      scrapeTimeout: {{ $monitor.scrapeTimeout | quote }}
+      {{- with $monitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $monitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end}}
+
 {{/*
 Helper to render TLS block if enabled
 */}}

--- a/charts/basyx/templates/postgres-podmonitors.yaml
+++ b/charts/basyx/templates/postgres-podmonitors.yaml
@@ -9,7 +9,7 @@
 {{- end }}
 {{- if and (eq (include "database.poolerEnabled" .) "true") .Values.database.pooler.monitoring.enabled }}
 ---
-{{- include "database.podMonitor" (dict
+{{ include "database.podMonitor" (dict
   "root" .
   "monitor" .Values.database.pooler.monitoring
   "name" (include "database.poolerName" .)

--- a/charts/basyx/templates/postgres-podmonitors.yaml
+++ b/charts/basyx/templates/postgres-podmonitors.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (include "database.managed" .) "true") .Values.database.monitoring.enabled -}}
+{{- include "database.podMonitor" (dict
+  "root" .
+  "monitor" .Values.database.monitoring
+  "name" .Values.database.clusterName
+  "selectorKey" "cnpg.io/cluster"
+  "selectorValue" .Values.database.clusterName
+) -}}
+{{- end }}
+{{- if and (eq (include "database.poolerEnabled" .) "true") .Values.database.pooler.monitoring.enabled }}
+---
+{{- include "database.podMonitor" (dict
+  "root" .
+  "monitor" .Values.database.pooler.monitoring
+  "name" (include "database.poolerName" .)
+  "selectorKey" "cnpg.io/poolerName"
+  "selectorValue" (include "database.poolerName" .)
+) -}}
+{{- end }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -20,7 +20,7 @@ The suites cover stable chart contracts such as:
 - optional DPP API deployment, ingress and ABAC wiring
 - Catena-X example values and marker-based ABAC wiring
 - common OIDC and ingress configuration
-- structured logging, optional OTLP traces and metrics, and telemetry Secret wiring
+- structured logging, optional OTLP traces and metrics, telemetry Secret wiring, and CloudNativePG PodMonitors
 - additional custom CA certificate mounts and trust-store wiring
 - runtime `helm test` hook for custom CA mount checks
 - service account helper behavior

--- a/charts/basyx/tests/fixtures/database_monitoring.yaml
+++ b/charts/basyx/tests/fixtures/database_monitoring.yaml
@@ -1,0 +1,30 @@
+database:
+  monitoring:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+    annotations:
+      monitoring.example.com/owner: platform
+    interval: 20s
+    scrapeTimeout: 5s
+    namespaceSelector:
+      matchNames:
+        - basyx-system
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_node_name
+        targetLabel: kubernetes_node
+        action: replace
+    metricRelabelings:
+      - sourceLabels:
+          - __name__
+        regex: go_.*
+        action: drop
+  pooler:
+    enabled: true
+    monitoring:
+      enabled: true
+      labels:
+        release: kube-prometheus-stack
+      interval: 15s
+      scrapeTimeout: 5s

--- a/charts/basyx/tests/fixtures/invalid_database_monitoring_hashmod.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_monitoring_hashmod.yaml
@@ -1,0 +1,7 @@
+database:
+  pooler:
+    monitoring:
+      metricRelabelings:
+        - action: hashmod
+          targetLabel: shard
+          modulus: 0

--- a/charts/basyx/tests/fixtures/invalid_database_monitoring_interval.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_monitoring_interval.yaml
@@ -1,0 +1,3 @@
+database:
+  monitoring:
+    interval: thirty-seconds

--- a/charts/basyx/tests/fixtures/invalid_database_monitoring_namespace.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_monitoring_namespace.yaml
@@ -1,0 +1,6 @@
+database:
+  pooler:
+    monitoring:
+      namespaceSelector:
+        matchNames:
+          - ""

--- a/charts/basyx/tests/fixtures/invalid_database_monitoring_relabeling.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_monitoring_relabeling.yaml
@@ -1,0 +1,4 @@
+database:
+  monitoring:
+    relabelings:
+      - action: unsupported

--- a/charts/basyx/tests/fixtures/invalid_database_monitoring_target_label.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_monitoring_target_label.yaml
@@ -1,0 +1,4 @@
+database:
+  monitoring:
+    relabelings:
+      - action: replace

--- a/charts/basyx/tests/postgres_monitoring_test.yaml
+++ b/charts/basyx/tests/postgres_monitoring_test.yaml
@@ -1,0 +1,121 @@
+suite: CloudNativePG monitoring
+release:
+  name: basyx
+  namespace: basyx-system
+templates:
+  - templates/postgres-podmonitors.yaml
+tests:
+  - it: does not render PodMonitors by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders PostgreSQL monitoring independently
+    set:
+      database.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: basyx-database
+      - equal:
+          path: spec.selector.matchLabels["cnpg.io/cluster"]
+          value: basyx-database
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+      - equal:
+          path: spec.podMetricsEndpoints[0].path
+          value: /metrics
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scrapeTimeout
+          value: 10s
+      - notExists:
+          path: spec.namespaceSelector
+
+  - it: renders RW Pooler monitoring independently when the Pooler is enabled
+    set:
+      database.pooler.enabled: true
+      database.pooler.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: metadata.name
+          value: basyx-database-rw-pooler
+      - equal:
+          path: spec.selector.matchLabels["cnpg.io/poolerName"]
+          value: basyx-database-rw-pooler
+
+  - it: renders both monitors with custom discovery and relabeling
+    values:
+      - fixtures/database_monitoring.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database
+        equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database
+        equal:
+          path: metadata.annotations["monitoring.example.com/owner"]
+          value: platform
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database
+        equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - basyx-system
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database
+        equal:
+          path: spec.podMetricsEndpoints[0].relabelings[0].targetLabel
+          value: kubernetes_node
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database
+        equal:
+          path: spec.podMetricsEndpoints[0].metricRelabelings[0].action
+          value: drop
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database-rw-pooler
+        equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 15s
+
+  - it: omits RW monitoring while the Pooler is disabled
+    set:
+      database.pooler.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits managed database monitors for an external database
+    set:
+      database.type: external
+      database.existingSecret: basyx-external-postgres
+      database.monitoring.enabled: true
+      database.pooler.enabled: true
+      database.pooler.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -268,6 +268,20 @@ tests:
       - failedTemplate:
           errorPattern: "database.monitoring.relabelings"
 
+  - it: fails when a database monitoring relabeling has no target label
+    values:
+      - fixtures/invalid_database_monitoring_target_label.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.monitoring.relabelings"
+
+  - it: fails when a Pooler monitoring hashmod modulus is zero
+    values:
+      - fixtures/invalid_database_monitoring_hashmod.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.pooler.monitoring.metricRelabelings"
+
   - it: fails when a Pooler monitoring namespace is empty
     values:
       - fixtures/invalid_database_monitoring_namespace.yaml

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -254,6 +254,27 @@ tests:
       - failedTemplate:
           errorPattern: "database.pooler.topologySpreadConstraints"
 
+  - it: fails when a database monitoring interval is invalid
+    values:
+      - fixtures/invalid_database_monitoring_interval.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.monitoring.interval"
+
+  - it: fails when a database monitoring relabeling action is unsupported
+    values:
+      - fixtures/invalid_database_monitoring_relabeling.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.monitoring.relabelings"
+
+  - it: fails when a Pooler monitoring namespace is empty
+    values:
+      - fixtures/invalid_database_monitoring_namespace.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.pooler.monitoring.namespaceSelector"
+
   - it: fails when minDomains is used with ScheduleAnyway
     values:
       - fixtures/invalid_database_min_domains.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -367,7 +367,67 @@
             "DropEqual"
           ]
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "not": {
+                  "required": ["action"]
+                }
+              },
+              {
+                "properties": {
+                  "action": {
+                    "enum": [
+                      "replace",
+                      "Replace",
+                      "hashmod",
+                      "HashMod",
+                      "lowercase",
+                      "Lowercase",
+                      "uppercase",
+                      "Uppercase",
+                      "keepequal",
+                      "KeepEqual",
+                      "dropequal",
+                      "DropEqual"
+                    ]
+                  }
+                },
+                "required": ["action"]
+              }
+            ]
+          },
+          "then": {
+            "required": ["targetLabel"],
+            "properties": {
+              "targetLabel": {
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "enum": ["hashmod", "HashMod"]
+              }
+            },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["modulus"],
+            "properties": {
+              "modulus": {
+                "minimum": 1
+              }
+            }
+          }
+        }
+      ]
     },
     "prometheusNamespaceSelector": {
       "type": "object",

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -314,6 +314,134 @@
         }
       }
     },
+    "prometheusRelabelConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sourceLabels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "separator": {
+          "type": "string"
+        },
+        "targetLabel": {
+          "type": "string"
+        },
+        "regex": {
+          "type": "string"
+        },
+        "modulus": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "replacement": {
+          "type": "string"
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "replace",
+            "Replace",
+            "keep",
+            "Keep",
+            "drop",
+            "Drop",
+            "hashmod",
+            "HashMod",
+            "labelmap",
+            "LabelMap",
+            "labeldrop",
+            "LabelDrop",
+            "labelkeep",
+            "LabelKeep",
+            "lowercase",
+            "Lowercase",
+            "uppercase",
+            "Uppercase",
+            "keepequal",
+            "KeepEqual",
+            "dropequal",
+            "DropEqual"
+          ]
+        }
+      }
+    },
+    "prometheusNamespaceSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "any": {
+          "type": "boolean"
+        },
+        "matchNames": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "podMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "labels",
+        "annotations",
+        "interval",
+        "scrapeTimeout",
+        "namespaceSelector",
+        "relabelings",
+        "metricRelabelings"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "interval": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/prometheusNamespaceSelector"
+        },
+        "relabelings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/prometheusRelabelConfig"
+          }
+        },
+        "metricRelabelings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/prometheusRelabelConfig"
+          }
+        }
+      }
+    },
     "serviceRuntimeOverrides": {
       "type": "object",
       "properties": {
@@ -1245,6 +1373,9 @@
             }
           }
         },
+        "monitoring": {
+          "$ref": "#/definitions/podMonitor"
+        },
         "pooler": {
           "type": "object",
           "required": [
@@ -1259,7 +1390,8 @@
             "nodeSelector",
             "affinity",
             "tolerations",
-            "topologySpreadConstraints"
+            "topologySpreadConstraints",
+            "monitoring"
           ],
           "properties": {
             "enabled": {
@@ -1422,6 +1554,9 @@
                   }
                 ]
               }
+            },
+            "monitoring": {
+              "$ref": "#/definitions/podMonitor"
             }
           }
         }

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1633,6 +1633,18 @@ database:
   # PostgreSQL settings accepted by CloudNativePG. Values must be strings.
   postgresql:
     parameters: {}
+  # Optional Prometheus Operator PodMonitor for the managed PostgreSQL pods.
+  # The chart does not install Prometheus Operator or its CRDs.
+  monitoring:
+    enabled: false
+    labels: {}
+    annotations: {}
+    interval: 30s
+    scrapeTimeout: 10s
+    # Empty selects pods in the PodMonitor's namespace.
+    namespaceSelector: {}
+    relabelings: []
+    metricRelabelings: []
   # Optional CloudNativePG read-write Pooler for BaSyx runtime services.
   # The Configuration Service always connects directly to the primary because
   # schema migrations use session-level advisory locks.
@@ -1653,6 +1665,17 @@ database:
     affinity: {}
     tolerations: []
     topologySpreadConstraints: []
+    # Optional Prometheus Operator PodMonitor for this Pooler.
+    monitoring:
+      enabled: false
+      labels: {}
+      annotations: {}
+      interval: 30s
+      scrapeTimeout: 10s
+      # Empty selects pods in the PodMonitor's namespace.
+      namespaceSelector: {}
+      relabelings: []
+      metricRelabelings: []
 
 # PodDisruptionBudget: not managed by this chart. For HA deployments, create
 # PDBs separately to guarantee availability during node drains. Example:


### PR DESCRIPTION
## What does this PR do?

Adds optional Prometheus Operator `PodMonitor` resources for the managed CloudNativePG PostgreSQL pods and the existing read-write Pooler. Both monitors are disabled by default and can be configured independently.

The values support discovery labels, annotations, scrape interval and timeout, namespace selection, relabelings, and metric relabelings. Relabel configurations validate required target labels and HashMod moduli before deployment. The generated resources use the documented `cnpg.io/cluster` and `cnpg.io/poolerName` selectors and scrape the named `metrics` port at `/metrics`.

The PostgreSQL monitor is omitted for external databases. The Pooler monitor is omitted unless the managed RW Pooler is enabled. The chart does not install Prometheus Operator or its CRDs.

RO Pooler monitoring is intentionally not part of this PR because the RO Pooler and reader configuration are tracked in #87.

The chart version is bumped to `3.8.0`; `appVersion` remains `1.0.6`.

## Validation

- 157 Helm unit tests
- `helm lint` with the default values, all example values files, and PostgreSQL/RW Pooler monitoring enabled
- `ct lint` including the chart version increment check
- chart package build
- server-side dry-run of both rendered PodMonitors against the Prometheus Operator `v0.93.0` CRD in a temporary kind cluster

Closes #86