### PR TITLE
Add PostgreSQL read replica routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,29 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - id: check
+        env:
+          GITHUB_EVENT_REPOSITORY_FORK: ${{ github.event.repository.fork }}
+        run: |
+          if [[ "${GITHUB_REPOSITORY}" == "eclipse-basyx/charts" && "${GITHUB_EVENT_REPOSITORY_FORK}" != "true" ]]; then
+            echo "✅ Running in upstream repository"
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⏭️ Skipping release — fork detected (${GITHUB_REPOSITORY})"
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   release:
+    needs: guard
+    if: ${{ needs.guard.outputs.should-run == 'true' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -24,7 +45,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
-        with: 
+        with:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -822,11 +822,121 @@ rolling updates, primary switchovers and connection saturation. Watch
 distinguish application-pool waits from PgBouncer queueing and PostgreSQL
 execution time.
 
+#### PostgreSQL reader routing and read-only Pooler
+
+BaSyx Go 1.0.7 can route eligible reads through a separate PostgreSQL
+connection. Chart 3.9.0 exposes this as `database.reader` and keeps it disabled
+by default. Without reader configuration, no `POSTGRES_READER_*` variables are
+rendered and every service continues to reuse its writer pool.
+
+For a managed CloudNativePG database, enabling the reader routes reads to the
+native `<database.clusterName>-ro` Service. When using this native endpoint,
+the cluster must have at least two instances:
+
+```yaml
+database:
+  instances: 3
+  reader:
+    enabled: true
+    maxOpenConnections: 50
+    maxIdleConnections: 25
+    connMaxLifetimeMinutes: 5
+    connMaxIdleTimeMinutes: 0
+```
+
+The optional read-only Pooler uses the same PgBouncer, resource and scheduling
+settings as the read-write Pooler:
+
+```yaml
+database:
+  instances: 3
+  reader:
+    enabled: true
+    pooler:
+      enabled: true
+      instances: 2
+      poolMode: transaction
+      maxClientConn: 1000
+      defaultPoolSize: 25
+      preparedStatements:
+        enabled: true
+        maxPreparedStatements: 100
+```
+
+This creates a CloudNativePG `Pooler` of type `ro` named
+`<database.clusterName>-ro-pooler` and uses its Service as the reader host.
+Writer traffic remains on the direct read-write Service or the separately
+configured `database.pooler`.
+
+For an external PostgreSQL deployment, reference a complete reader Secret:
+
+```yaml
+database:
+  type: external
+  existingSecret: basyx-postgres-writer
+  reader:
+    enabled: true
+    existingSecret: basyx-postgres-reader
+```
+
+The reader Secret must contain `host`, `port`, `dbname`, `user` and `password`.
+It can also contain the optional PostgreSQL keys accepted by the writer Secret.
+Alternatively, configure only a separate endpoint and reuse the effective
+writer Secret for omitted fields:
+
+```yaml
+database:
+  type: external
+  existingSecret: basyx-postgres-writer
+  reader:
+    enabled: true
+    host: postgres-reader.example.internal
+    sslmode: verify-full
+```
+
+Inline reader connection values are stored in a generated Secret. Prefer
+existing Secrets, TLS with server verification and a least-privilege read-only
+user in production. For endpoints that do not enforce read-only transactions,
+consider `options: "-c default_transaction_read_only=on"` as an additional
+safeguard after verifying provider compatibility. A managed writer with one
+instance can use an explicit external reader `host` or `existingSecret`.
+Setting only `reader.enabled: true` for an external database deliberately
+reuses the complete writer endpoint; it is compatible with the reader routing
+feature but does not add database capacity.
+
+Each charted BaSyx Go HTTP service supports a complete local reader replacement
+at `<component>.database.reader`: AAS and Submodel Registry, Discovery Service,
+Digital Twin Registry, AAS and Submodel Repository, Concept Description
+Repository, AAS Environment, Company Lookup Service and DPP API. A reader-only
+local override retains the global writer. A service-local writer override
+without a local reader disables global reader inheritance so that the service
+cannot accidentally query another database. The Configuration Service and
+Keycloak remain writer-only. BaSyx Go also supports reader routing in the AASX
+File Server, but that service is not currently deployed by this chart.
+
+Reader results are eventually consistent. Replication lag can briefly expose
+the preceding state after writes, deletions and authorization-relevant
+attribute changes. Mutation, transaction, guard and read-after-write work
+continues to use the writer. Deployments requiring immediate revocation or
+read-after-write consistency must leave the affected service on the writer or
+use replication guarantees that meet their consistency window. Reader startup
+fails if the configured endpoint is unavailable; requests are not silently
+routed back to the writer.
+
+Budget the four reader pool values independently for every BaSyx pod and
+destination standby. Aggregate BaSyx clients must fit the capacity of the
+surviving read-only Pooler pods. PostgreSQL server-connection budgeting must
+include every active read-only Pooler pod, every user/database pool, and
+distribution or failover across the standbys. Monitor replication lag together
+with BaSyx `db.client.connections.*` and CloudNativePG `cnpg_pgbouncer_*`
+metrics before increasing limits. Start from
+[`values/values.read-replica.example.yaml`](values/values.read-replica.example.yaml).
+
 #### Database and Pooler PodMonitors
 
 The chart can create Prometheus Operator `PodMonitor` resources for the managed
-CloudNativePG instances and the read-write Pooler. Both are disabled by default,
-and the chart does not install Prometheus Operator or the
+CloudNativePG instances, the read-write Pooler and the read-only Pooler. All are
+disabled by default, and the chart does not install Prometheus Operator or the
 `monitoring.coreos.com` CRDs.
 
 ```yaml
@@ -859,13 +969,27 @@ database:
       namespaceSelector: {}
       relabelings: []
       metricRelabelings: []
+  reader:
+    enabled: true
+    pooler:
+      enabled: true
+      monitoring:
+        enabled: true
+        labels:
+          release: kube-prometheus-stack
+        annotations: {}
+        interval: 30s
+        scrapeTimeout: 10s
+        namespaceSelector: {}
+        relabelings: []
+        metricRelabelings: []
 ```
 
 PostgreSQL and Pooler monitoring can be enabled independently. The PostgreSQL
-monitor is rendered only for a managed database. The Pooler monitor is rendered
-only when the managed read-write Pooler is also enabled. Neither monitor is
-rendered for `database.type: external`; monitoring an external database remains
-the responsibility of that database's platform.
+monitor is rendered only for a managed database. Each Pooler monitor is
+rendered only when its corresponding managed Pooler is enabled. None of these
+monitors is rendered for `database.type: external`; monitoring an external
+database remains the responsibility of that database's platform.
 
 The chart selects PostgreSQL pods through `cnpg.io/cluster` and Pooler pods
 through `cnpg.io/poolerName`. Both exporters are scraped through the named

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.8.0
-appVersion: "1.0.6"
+version: 3.9.0
+appVersion: "1.0.7"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -758,7 +758,8 @@ Create the name of the service account to use
 {{- $componentValues = get $root.Values $component | default dict -}}
 {{- end -}}
 {{- $serviceDatabase := get $componentValues "database" | default dict -}}
-{{- if and $component $serviceDatabase -}}
+{{- $serviceWriterDatabase := omit $serviceDatabase "reader" -}}
+{{- if and $component $serviceWriterDatabase -}}
 {{- if $serviceDatabase.existingSecret -}}
 {{- $serviceDatabase.existingSecret | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -780,6 +781,94 @@ Create the name of the service account to use
 {{- printf "%s\n%s\n%s\n" (include "database.serviceSecret" .) (toYaml $root.Values.database) (toYaml $serviceDatabase) | sha256sum -}}
 {{- end}}
 
+{{- define "database.serviceWriterOverride" -}}
+{{- $componentValues := get .root.Values (.component | default "") | default dict -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- if gt (len (omit $serviceDatabase "reader")) 0 -}}true{{- else -}}false{{- end -}}
+{{- end}}
+
+{{- define "database.readerConfig" -}}
+{{- $root := .root -}}
+{{- $componentValues := get $root.Values (.component | default "") | default dict -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- if hasKey $serviceDatabase "reader" -}}
+{{- toYaml (get $serviceDatabase "reader") -}}
+{{- else if eq (include "database.serviceWriterOverride" .) "true" -}}
+enabled: false
+{{- else -}}
+{{- toYaml $root.Values.database.reader -}}
+{{- end -}}
+{{- end}}
+
+{{- define "database.readerEnabled" -}}
+{{- $reader := include "database.readerConfig" . | fromYaml | default dict -}}
+{{- if $reader.enabled -}}true{{- else -}}false{{- end -}}
+{{- end}}
+
+{{- define "database.readerManaged" -}}
+{{- $reader := include "database.readerConfig" . | fromYaml | default dict -}}
+{{- if and
+  (eq (include "database.managed" .root) "true")
+  (eq (include "database.serviceWriterOverride" .) "false")
+  (not ($reader.existingSecret | default ""))
+  (not ($reader.host | default ""))
+-}}true{{- else -}}false{{- end -}}
+{{- end}}
+
+{{- define "database.readerGeneratedSecretName" -}}
+{{- printf "%s-reader-database" (include "basyx.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end}}
+
+{{- define "database.serviceReaderGeneratedSecretName" -}}
+{{- $root := .root -}}
+{{- $name := .nameSuffix | default .component | toString | kebabcase -}}
+{{- printf "%s-%s-reader-database" (include "basyx.fullname" $root) $name | trunc 63 | trimSuffix "-" -}}
+{{- end}}
+
+{{- define "database.readerSecret" -}}
+{{- $reader := include "database.readerConfig" . | fromYaml | default dict -}}
+{{- if $reader.existingSecret -}}
+{{- $reader.existingSecret | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $componentValues := get .root.Values (.component | default "") | default dict -}}
+{{- $serviceDatabase := get $componentValues "database" | default dict -}}
+{{- if hasKey $serviceDatabase "reader" -}}
+{{- include "database.serviceReaderGeneratedSecretName" . -}}
+{{- else -}}
+{{- include "database.readerGeneratedSecretName" .root -}}
+{{- end -}}
+{{- end -}}
+{{- end}}
+
+{{- define "database.readerHasInlineValues" -}}
+{{- $hasInlineValues := false -}}
+{{- range $key := list "host" "port" "dbname" "user" "password" "sslmode" "sslcert" "sslkey" "sslrootcert" "connectTimeoutSeconds" "applicationName" "fallbackApplicationName" "searchPath" "options" "timezone" -}}
+{{- if get $.reader $key -}}
+{{- $hasInlineValues = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $hasInlineValues -}}true{{- else -}}false{{- end -}}
+{{- end}}
+
+{{- define "database.readerSecretResource" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "basyx.labels" .root | nindent 4 }}
+    {{- with .component }}
+    app.kubernetes.io/component: {{ . | quote }}
+    {{- end }}
+type: Opaque
+stringData:
+  {{- range $key := list "host" "port" "dbname" "user" "password" "sslmode" "sslcert" "sslkey" "sslrootcert" "connectTimeoutSeconds" "applicationName" "fallbackApplicationName" "searchPath" "options" "timezone" }}
+  {{- with get $.reader $key }}
+  {{ $key }}: {{ . | toString | quote }}
+  {{- end }}
+  {{- end }}
+{{- end}}
+
 {{- define "database.optionalEnv" -}}
 - name: {{ .name }}
   valueFrom:
@@ -787,6 +876,17 @@ Create the name of the service account to use
       name: {{ .secret }}
       key: {{ .key }}
       optional: true
+{{- end }}
+
+{{- define "database.readerSecretEnv" -}}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{- if or .complete (get .reader .key) }} {{ .readerSecret }}{{- else }} {{ .writerSecret }}{{- end }}
+      key: {{ .key }}
+      {{- if .optional }}
+      optional: true
+      {{- end }}
 {{- end }}
 
 {{- define "database.managed" -}}
@@ -798,6 +898,10 @@ Create the name of the service account to use
 {{- if and (eq (include "database.managed" .) "true") .Values.database.pooler.enabled -}}true{{- else -}}false{{- end -}}
 {{- end}}
 
+{{- define "database.readOnlyPoolerEnabled" -}}
+{{- if and (eq (include "database.managed" .) "true") .Values.database.reader.enabled .Values.database.reader.pooler.enabled -}}true{{- else -}}false{{- end -}}
+{{- end}}
+
 {{- define "database.poolerName" -}}
 {{- $clusterName := .Values.database.clusterName -}}
 {{- $poolerName := printf "%s-rw-pooler" ($clusterName | trunc 53 | trimSuffix "-") -}}
@@ -805,6 +909,75 @@ Create the name of the service account to use
 {{- $poolerName = printf "%s-rw-pooler" ($clusterName | trunc 52 | trimSuffix "-") -}}
 {{- end -}}
 {{- $poolerName -}}
+{{- end}}
+
+{{- define "database.readOnlyPoolerName" -}}
+{{- $clusterName := .Values.database.clusterName -}}
+{{- $poolerName := printf "%s-ro-pooler" ($clusterName | trunc 53 | trimSuffix "-") -}}
+{{- if eq $poolerName $clusterName -}}
+{{- $poolerName = printf "%s-ro-pooler" ($clusterName | trunc 52 | trimSuffix "-") -}}
+{{- end -}}
+{{- $poolerName -}}
+{{- end}}
+
+{{- define "database.readOnlyServiceName" -}}
+{{- printf "%s-ro" .Values.database.clusterName -}}
+{{- end}}
+
+{{- define "database.poolerResource" -}}
+{{- $root := .root -}}
+{{- $pooler := .pooler -}}
+{{- $parameters := deepCopy ($pooler.parameters | default dict) -}}
+{{- $_ := set $parameters "max_client_conn" ($pooler.maxClientConn | toString) -}}
+{{- $_ := set $parameters "default_pool_size" ($pooler.defaultPoolSize | toString) -}}
+{{- $maxPreparedStatements := "0" -}}
+{{- if $pooler.preparedStatements.enabled -}}
+{{- $maxPreparedStatements = $pooler.preparedStatements.maxPreparedStatements | toString -}}
+{{- end -}}
+{{- $_ := set $parameters "max_prepared_statements" $maxPreparedStatements -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "basyx.labels" $root | nindent 4 }}
+spec:
+  cluster:
+    name: {{ $root.Values.database.clusterName }}
+  instances: {{ $pooler.instances }}
+  type: {{ .type }}
+  pgbouncer:
+    poolMode: {{ $pooler.poolMode }}
+    parameters:
+      {{- toYaml $parameters | nindent 6 }}
+  {{- if or $pooler.resources $pooler.nodeSelector $pooler.affinity $pooler.tolerations $pooler.topologySpreadConstraints }}
+  template:
+    spec:
+      {{- if $pooler.resources }}
+      containers:
+        - name: pgbouncer
+          resources:
+            {{- toYaml $pooler.resources | nindent 12 }}
+      {{- else }}
+      containers: []
+      {{- end }}
+      {{- with $pooler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pooler.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
 {{- end}}
 
 {{- define "database.podMonitor" -}}
@@ -1026,7 +1199,8 @@ annotations:
 {{- $databaseSecret := include "database.serviceSecret" $secretContext -}}
 {{- $componentValues := get $root.Values $component | default dict -}}
 {{- $serviceDatabase := get $componentValues "database" | default dict -}}
-{{- $usePooler := and $component (not $serviceDatabase) (eq (include "database.poolerEnabled" $root) "true") -}}
+{{- $serviceWriterDatabase := omit $serviceDatabase "reader" -}}
+{{- $usePooler := and $component (not $serviceWriterDatabase) (eq (include "database.poolerEnabled" $root) "true") -}}
 - name: POSTGRES_PORT
   valueFrom:
     secretKeyRef:
@@ -1066,6 +1240,58 @@ annotations:
 {{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_SEARCHPATH" "key" "searchPath") }}
 {{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_OPTIONS" "key" "options") }}
 {{ include "database.optionalEnv" (dict "secret" $databaseSecret "name" "POSTGRES_TIMEZONE" "key" "timezone") }}
+{{ if $component }}
+{{- $readerContext := dict "root" $root "component" $component "nameSuffix" $nameSuffix -}}
+{{- if eq (include "database.readerEnabled" $readerContext) "true" }}
+{{- $reader := include "database.readerConfig" $readerContext | fromYaml | default dict -}}
+{{- $readerSecret := include "database.readerSecret" $readerContext -}}
+{{- $completeReaderSecret := ne ($reader.existingSecret | default "") "" -}}
+{{- $readerManaged := eq (include "database.readerManaged" $readerContext) "true" -}}
+- name: POSTGRES_READER_HOST
+  {{- if $readerManaged }}
+  value: {{- if eq (include "database.readOnlyPoolerEnabled" $root) "true" }} {{ include "database.readOnlyPoolerName" $root | quote }}{{- else }} {{ include "database.readOnlyServiceName" $root | quote }}{{- end }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{- if or $completeReaderSecret ($reader.host | default "") }} {{ $readerSecret }}{{- else }} {{ $databaseSecret }}{{- end }}
+      key: host
+  {{- end }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_PORT" "key" "port" "optional" false) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_PASSWORD" "key" "password" "optional" false) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_DBNAME" "key" "dbname" "optional" false) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_USER" "key" "user" "optional" false) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_SSLMODE" "key" "sslmode" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_SSLCERT" "key" "sslcert" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_SSLKEY" "key" "sslkey" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_SSLROOTCERT" "key" "sslrootcert" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_CONNECTTIMEOUTSECONDS" "key" "connectTimeoutSeconds" "optional" true) }}
+{{ if or $completeReaderSecret ($reader.applicationName | default "") }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_APPLICATIONNAME" "key" "applicationName" "optional" true) }}
+{{ end }}
+{{ if or $completeReaderSecret ($reader.fallbackApplicationName | default "") }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_FALLBACKAPPLICATIONNAME" "key" "fallbackApplicationName" "optional" true) }}
+{{ end }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_SEARCHPATH" "key" "searchPath" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_OPTIONS" "key" "options" "optional" true) }}
+{{ include "database.readerSecretEnv" (dict "reader" $reader "readerSecret" $readerSecret "writerSecret" $databaseSecret "complete" $completeReaderSecret "name" "POSTGRES_READER_TIMEZONE" "key" "timezone" "optional" true) }}
+{{ $maxOpenConnections := 50 -}}
+{{- if hasKey $reader "maxOpenConnections" }}{{- $maxOpenConnections = $reader.maxOpenConnections -}}{{- end }}
+{{- $maxIdleConnections := 25 -}}
+{{- if hasKey $reader "maxIdleConnections" }}{{- $maxIdleConnections = $reader.maxIdleConnections -}}{{- end }}
+{{- $connMaxLifetimeMinutes := 5 -}}
+{{- if hasKey $reader "connMaxLifetimeMinutes" }}{{- $connMaxLifetimeMinutes = $reader.connMaxLifetimeMinutes -}}{{- end }}
+{{- $connMaxIdleTimeMinutes := 0 -}}
+{{- if hasKey $reader "connMaxIdleTimeMinutes" }}{{- $connMaxIdleTimeMinutes = $reader.connMaxIdleTimeMinutes -}}{{- end }}
+- name: POSTGRES_READER_MAXOPENCONNECTIONS
+  value: {{ $maxOpenConnections | quote }}
+- name: POSTGRES_READER_MAXIDLECONNECTIONS
+  value: {{ $maxIdleConnections | quote }}
+- name: POSTGRES_READER_CONNMAXLIFETIMEMINUTES
+  value: {{ $connMaxLifetimeMinutes | quote }}
+- name: POSTGRES_READER_CONNMAXIDLETIMEMINUTES
+  value: {{ $connMaxIdleTimeMinutes | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "basyx.abac.enabled" -}}

--- a/charts/basyx/templates/database-secret.yaml
+++ b/charts/basyx/templates/database-secret.yaml
@@ -59,7 +59,16 @@ stringData:
   {{- end }}
   {{- with (get $external "timezone") }}
   timezone: {{ . | toString | quote }}
-  {{- end }}
+{{- end }}
+{{- end }}
+{{- $globalReader := .Values.database.reader | default dict -}}
+{{- if and $globalReader.enabled (not $globalReader.existingSecret) (eq (include "database.readerHasInlineValues" (dict "reader" $globalReader)) "true") }}
+---
+{{ include "database.readerSecretResource" (dict
+  "root" .
+  "reader" $globalReader
+  "name" (include "database.readerGeneratedSecretName" .)
+) }}
 {{- end }}
 {{- $root := . -}}
 {{- $components := list
@@ -77,7 +86,8 @@ stringData:
 {{- range $service := $components }}
 {{- $values := get $root.Values $service.component | default dict -}}
 {{- $serviceDatabase := get $values "database" | default dict -}}
-{{- if and $values.enabled $serviceDatabase (not $serviceDatabase.existingSecret) }}
+{{- $serviceWriterDatabase := omit $serviceDatabase "reader" -}}
+{{- if and $values.enabled $serviceWriterDatabase (not $serviceDatabase.existingSecret) }}
 {{- $external := get $serviceDatabase "external" | default dict -}}
 {{- $host := required (printf "%s.database.host or %s.database.external.host is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "host") (get $serviceDatabase "host")) -}}
 {{- $port := required (printf "%s.database.port or %s.database.external.port is required when %s.database.existingSecret is empty" $service.component $service.component $service.component) (default (get $external "port") (get $serviceDatabase "port")) -}}
@@ -150,6 +160,18 @@ stringData:
   {{- end }}
   {{- with $timezone }}
   timezone: {{ . | toString | quote }}
-  {{- end }}
+{{- end }}
+{{- end }}
+{{- if and $values.enabled (hasKey $serviceDatabase "reader") }}
+{{- $serviceReader := get $serviceDatabase "reader" | default dict -}}
+{{- if and $serviceReader.enabled (not $serviceReader.existingSecret) (eq (include "database.readerHasInlineValues" (dict "reader" $serviceReader)) "true") }}
+---
+{{ include "database.readerSecretResource" (dict
+  "root" $root
+  "reader" $serviceReader
+  "name" (include "database.serviceReaderGeneratedSecretName" (dict "root" $root "component" $service.component "nameSuffix" $service.nameSuffix))
+  "component" $service.nameSuffix
+) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/basyx/templates/postgres-podmonitors.yaml
+++ b/charts/basyx/templates/postgres-podmonitors.yaml
@@ -17,3 +17,13 @@
   "selectorValue" (include "database.poolerName" .)
 ) -}}
 {{- end }}
+{{- if and (eq (include "database.readOnlyPoolerEnabled" .) "true") .Values.database.reader.pooler.monitoring.enabled }}
+---
+{{ include "database.podMonitor" (dict
+  "root" .
+  "monitor" .Values.database.reader.pooler.monitoring
+  "name" (include "database.readOnlyPoolerName" .)
+  "selectorKey" "cnpg.io/poolerName"
+  "selectorValue" (include "database.readOnlyPoolerName" .)
+) -}}
+{{- end }}

--- a/charts/basyx/templates/postgres-pooler.yaml
+++ b/charts/basyx/templates/postgres-pooler.yaml
@@ -1,54 +1,7 @@
 {{- if eq (include "database.poolerEnabled" .) "true" -}}
-{{- $pooler := .Values.database.pooler -}}
-{{- $parameters := deepCopy ($pooler.parameters | default dict) -}}
-{{- $_ := set $parameters "max_client_conn" ($pooler.maxClientConn | toString) -}}
-{{- $_ := set $parameters "default_pool_size" ($pooler.defaultPoolSize | toString) -}}
-{{- $maxPreparedStatements := "0" -}}
-{{- if $pooler.preparedStatements.enabled -}}
-{{- $maxPreparedStatements = $pooler.preparedStatements.maxPreparedStatements | toString -}}
-{{- end -}}
-{{- $_ := set $parameters "max_prepared_statements" $maxPreparedStatements -}}
-apiVersion: postgresql.cnpg.io/v1
-kind: Pooler
-metadata:
-  name: {{ include "database.poolerName" . }}
-  labels:
-    {{- include "basyx.labels" . | nindent 4 }}
-spec:
-  cluster:
-    name: {{ .Values.database.clusterName }}
-  instances: {{ $pooler.instances }}
-  type: rw
-  pgbouncer:
-    poolMode: {{ $pooler.poolMode }}
-    parameters:
-      {{- toYaml $parameters | nindent 6 }}
-  {{- if or $pooler.resources $pooler.nodeSelector $pooler.affinity $pooler.tolerations $pooler.topologySpreadConstraints }}
-  template:
-    spec:
-      {{- if $pooler.resources }}
-      containers:
-        - name: pgbouncer
-          resources:
-            {{- toYaml $pooler.resources | nindent 12 }}
-      {{- else }}
-      containers: []
-      {{- end }}
-      {{- with $pooler.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $pooler.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $pooler.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $pooler.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-  {{- end }}
+{{- include "database.poolerResource" (dict "root" . "pooler" .Values.database.pooler "name" (include "database.poolerName" .) "type" "rw") }}
+{{- end }}
+{{- if eq (include "database.readOnlyPoolerEnabled" .) "true" }}
+---
+{{ include "database.poolerResource" (dict "root" . "pooler" .Values.database.reader.pooler "name" (include "database.readOnlyPoolerName" .) "type" "ro") }}
 {{- end }}

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -27,6 +27,6 @@ The suites cover stable chart contracts such as:
 - digest-aware image rendering
 - schema validation for required values and basic formats
 - managed PostgreSQL storage, WAL, resources, scheduling and parameters
-- optional CloudNativePG read-write Pooler rendering and connection routing
+- optional CloudNativePG read-write and read-only Pooler rendering, reader routing, and monitoring
 - shared per-pod PostgreSQL pool defaults and Configuration Service propagation
 - keycloak init resources and a runtime `helm test` realm check

--- a/charts/basyx/tests/fixtures/database_reader_all_services.yaml
+++ b/charts/basyx/tests/fixtures/database_reader_all_services.yaml
@@ -1,0 +1,24 @@
+database:
+  reader:
+    enabled: true
+
+aasDiscovery:
+  enabled: true
+aasRegistry:
+  enabled: true
+aasRepository:
+  enabled: true
+aasEnvironment:
+  enabled: true
+dppApi:
+  enabled: true
+submodelRegistry:
+  enabled: true
+submodelRepository:
+  enabled: true
+cdRepository:
+  enabled: true
+companyLookup:
+  enabled: true
+digitalTwinRegistry:
+  enabled: true

--- a/charts/basyx/tests/fixtures/database_reader_pooler.yaml
+++ b/charts/basyx/tests/fixtures/database_reader_pooler.yaml
@@ -1,0 +1,47 @@
+database:
+  reader:
+    enabled: true
+    pooler:
+      enabled: true
+      instances: 3
+      poolMode: session
+      maxClientConn: 600
+      defaultPoolSize: 30
+      preparedStatements:
+        enabled: true
+        maxPreparedStatements: 150
+      parameters:
+        max_client_conn: "10"
+        default_pool_size: "5"
+        max_prepared_statements: "1"
+        reserve_pool_size: "4"
+      resources:
+        requests:
+          cpu: 250m
+      nodeSelector:
+        workload: database
+      affinity: {}
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      topologySpreadConstraints: []
+      monitoring:
+        enabled: true
+        labels:
+          release: kube-prometheus-stack
+        annotations:
+          monitoring.example.com/owner: platform
+        interval: 15s
+        scrapeTimeout: 5s
+        namespaceSelector:
+          matchNames:
+            - basyx-system
+        relabelings:
+          - sourceLabels:
+              - __meta_kubernetes_pod_node_name
+            targetLabel: kubernetes_node
+        metricRelabelings:
+          - sourceLabels:
+              - __name__
+            regex: go_.*
+            action: drop

--- a/charts/basyx/tests/fixtures/invalid_database_reader_monitoring_without_pooler.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_reader_monitoring_without_pooler.yaml
@@ -1,0 +1,7 @@
+database:
+  reader:
+    enabled: true
+    pooler:
+      enabled: false
+      monitoring:
+        enabled: true

--- a/charts/basyx/tests/fixtures/invalid_database_reader_pool.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_reader_pool.yaml
@@ -1,0 +1,3 @@
+database:
+  reader:
+    maxOpenConnections: -1

--- a/charts/basyx/tests/fixtures/invalid_database_reader_pooler_disabled.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_reader_pooler_disabled.yaml
@@ -1,0 +1,5 @@
+database:
+  reader:
+    enabled: false
+    pooler:
+      enabled: true

--- a/charts/basyx/tests/fixtures/invalid_database_reader_pooler_external.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_reader_pooler_external.yaml
@@ -1,0 +1,7 @@
+database:
+  type: external
+  existingSecret: basyx-writer
+  reader:
+    enabled: true
+    pooler:
+      enabled: true

--- a/charts/basyx/tests/fixtures/invalid_database_reader_single_instance.yaml
+++ b/charts/basyx/tests/fixtures/invalid_database_reader_single_instance.yaml
@@ -1,0 +1,4 @@
+database:
+  instances: 1
+  reader:
+    enabled: true

--- a/charts/basyx/tests/postgres_monitoring_test.yaml
+++ b/charts/basyx/tests/postgres_monitoring_test.yaml
@@ -119,3 +119,40 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: renders read-only Pooler monitoring with the Pooler selector
+    values:
+      - fixtures/database_reader_pooler.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: metadata.name
+          value: basyx-database-ro-pooler
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+      - equal:
+          path: metadata.annotations["monitoring.example.com/owner"]
+          value: platform
+      - equal:
+          path: spec.selector.matchLabels["cnpg.io/poolerName"]
+          value: basyx-database-ro-pooler
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - basyx-system
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 15s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scrapeTimeout
+          value: 5s
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[0].targetLabel
+          value: kubernetes_node
+      - equal:
+          path: spec.podMetricsEndpoints[0].metricRelabelings[0].action
+          value: drop

--- a/charts/basyx/tests/postgres_pooler_test.yaml
+++ b/charts/basyx/tests/postgres_pooler_test.yaml
@@ -1,4 +1,4 @@
-suite: CloudNativePG read-write Pooler
+suite: CloudNativePG Poolers
 release:
   name: basyx
 templates:
@@ -216,3 +216,125 @@ tests:
           content:
             name: POSTGRES_HOST
             value: basyx-database-rw-pooler
+
+  - it: renders a read-only Pooler for an enabled managed reader
+    template: templates/postgres-pooler.yaml
+    set:
+      database.reader.enabled: true
+      database.reader.pooler.enabled: true
+    asserts:
+      - isKind:
+          of: Pooler
+      - equal:
+          path: metadata.name
+          value: basyx-database-ro-pooler
+      - equal:
+          path: spec.cluster.name
+          value: basyx-database
+      - equal:
+          path: spec.type
+          value: ro
+      - equal:
+          path: spec.instances
+          value: 2
+      - equal:
+          path: spec.pgbouncer.poolMode
+          value: transaction
+      - equal:
+          path: spec.pgbouncer.parameters.max_client_conn
+          value: "1000"
+      - equal:
+          path: spec.pgbouncer.parameters.default_pool_size
+          value: "25"
+      - equal:
+          path: spec.pgbouncer.parameters.max_prepared_statements
+          value: "100"
+
+  - it: renders read-write and read-only Poolers independently
+    template: templates/postgres-pooler.yaml
+    set:
+      database.pooler.enabled: true
+      database.reader.enabled: true
+      database.reader.pooler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database-rw-pooler
+        equal:
+          path: spec.type
+          value: rw
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database-ro-pooler
+        equal:
+          path: spec.type
+          value: ro
+
+  - it: keeps a maximum-length read-only Pooler name valid and distinct
+    template: templates/postgres-pooler.yaml
+    set:
+      database.clusterName: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      database.reader.enabled: true
+      database.reader.pooler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ro-pooler
+      - equal:
+          path: spec.cluster.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  - it: renders read-only Pooler scheduling and parameter precedence
+    template: templates/postgres-pooler.yaml
+    values:
+      - fixtures/database_reader_pooler.yaml
+    asserts:
+      - equal:
+          path: spec.instances
+          value: 3
+      - equal:
+          path: spec.pgbouncer.poolMode
+          value: session
+      - equal:
+          path: spec.pgbouncer.parameters.max_client_conn
+          value: "600"
+      - equal:
+          path: spec.pgbouncer.parameters.default_pool_size
+          value: "30"
+      - equal:
+          path: spec.pgbouncer.parameters.max_prepared_statements
+          value: "150"
+      - equal:
+          path: spec.pgbouncer.parameters.reserve_pool_size
+          value: "4"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.nodeSelector.workload
+          value: database
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: NoSchedule
+
+  - it: renders both Poolers from the read-replica example
+    template: templates/postgres-pooler.yaml
+    values:
+      - ../../../values/values.read-replica.example.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database-rw-pooler
+        equal:
+          path: spec.type
+          value: rw
+      - documentSelector:
+          path: metadata.name
+          value: basyx-database-ro-pooler
+        equal:
+          path: spec.type
+          value: ro

--- a/charts/basyx/tests/postgres_reader_test.yaml
+++ b/charts/basyx/tests/postgres_reader_test.yaml
@@ -1,0 +1,423 @@
+suite: PostgreSQL reader configuration
+release:
+  name: basyx
+templates:
+  - templates/database-secret.yaml
+  - templates/configuration-service-job.yaml
+  - templates/keycloak/deployment.yaml
+  - templates/aas-discovery/deployment.yaml
+  - templates/aas-registry/deployment.yaml
+  - templates/aas-repository/deployment.yaml
+  - templates/aas-environment/deployment.yaml
+  - templates/dpp-api/deployment.yaml
+  - templates/submodel-registry/deployment.yaml
+  - templates/submodel-repository/deployment.yaml
+  - templates/cd-repository/deployment.yaml
+  - templates/company-lookup/deployment.yaml
+  - templates/digital-twin-registry/deployment.yaml
+tests:
+  - it: does not inject reader configuration by default
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+
+  - it: routes a managed reader directly to the CloudNativePG read-only service
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.reader.enabled: true
+      database.reader.maxOpenConnections: 40
+      database.reader.maxIdleConnections: 20
+      database.reader.connMaxLifetimeMinutes: 10
+      database.reader.connMaxIdleTimeMinutes: 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            value: basyx-database-ro
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: password
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_MAXOPENCONNECTIONS
+            value: "40"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_MAXIDLECONNECTIONS
+            value: "20"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_CONNMAXLIFETIMEMINUTES
+            value: "10"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_CONNMAXIDLETIMEMINUTES
+            value: "2"
+          count: 1
+
+  - it: routes a managed reader through the read-only Pooler when enabled
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.reader.enabled: true
+      database.reader.pooler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            value: basyx-database-ro-pooler
+          count: 1
+
+  - it: routes through the read-only Pooler from the read-replica example
+    template: templates/aas-environment/deployment.yaml
+    values:
+      - ../../../values/values.read-replica.example.yaml
+    set:
+      aasEnvironment.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            value: basyx-database-ro-pooler
+          count: 1
+
+  - it: uses a complete external reader Secret
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-writer
+      database.reader.enabled: true
+      database.reader.existingSecret: basyx-reader
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-reader
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basyx-reader
+                key: password
+          count: 1
+
+  - it: stores an inline reader endpoint in a Secret and reuses writer credentials
+    template: templates/database-secret.yaml
+    set:
+      database.type: external
+      database.existingSecret: basyx-writer
+      database.reader.enabled: true
+      database.reader.host: postgres-reader.example.internal
+      database.reader.sslmode: verify-full
+    documentSelector:
+      path: metadata.name
+      value: basyx-reader-database
+    asserts:
+      - equal:
+          path: stringData.host
+          value: postgres-reader.example.internal
+      - equal:
+          path: stringData.sslmode
+          value: verify-full
+      - notExists:
+          path: stringData.password
+
+  - it: sources omitted inline reader fields from the writer Secret
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-writer
+      database.reader.enabled: true
+      database.reader.host: postgres-reader.example.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-reader-database
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basyx-writer
+                key: password
+          count: 1
+
+  - it: supports the same external endpoint for writer and reader
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-writer
+      database.reader.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-writer
+                key: host
+          count: 1
+
+  - it: allows a managed writer with one instance and an explicit external reader
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.instances: 1
+      database.reader.enabled: true
+      database.reader.host: postgres-reader.example.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-reader-database
+                key: host
+          count: 1
+
+  - it: does not inherit the writer application name
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.type: external
+      database.existingSecret: basyx-writer
+      database.reader.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_APPLICATIONNAME
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_FALLBACKAPPLICATIONNAME
+
+  - it: disables global reader inheritance for a service-local writer
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.reader.enabled: true
+      aasRegistry.database.existingSecret: registry-writer
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: registry-writer
+                key: host
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+
+  - it: supports a reader-only service override with the global writer
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      aasRegistry.database.reader.enabled: true
+      aasRegistry.database.reader.host: registry-reader.example.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-database-app
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: basyx-aas-registry-reader-database
+                key: host
+          count: 1
+
+  - it: allows a service to disable the global reader
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.reader.enabled: true
+      aasRegistry.database.reader.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+
+  - it: uses service-local writer and reader Secrets together
+    template: templates/aas-registry/deployment.yaml
+    set:
+      aasRegistry.enabled: true
+      database.reader.enabled: true
+      aasRegistry.database.existingSecret: registry-writer
+      aasRegistry.database.reader.enabled: true
+      aasRegistry.database.reader.existingSecret: registry-reader
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: registry-writer
+                key: host
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            valueFrom:
+              secretKeyRef:
+                name: registry-reader
+                key: host
+          count: 1
+
+  - it: keeps the Configuration Service writer-only
+    template: templates/configuration-service-job.yaml
+    set:
+      database.reader.enabled: true
+      database.reader.pooler.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+
+  - it: keeps Keycloak writer-only
+    template: templates/keycloak/deployment.yaml
+    set:
+      keycloak.enabled: true
+      database.reader.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+
+  - it: injects the reader into the Discovery Service
+    template: templates/aas-discovery/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: &managedReaderHost
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_READER_HOST
+            value: basyx-database-ro
+          count: 1
+
+  - it: injects the reader into the AAS Registry
+    template: templates/aas-registry/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the AAS Repository
+    template: templates/aas-repository/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the AAS Environment
+    template: templates/aas-environment/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the DPP API
+    template: templates/dpp-api/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the Submodel Registry
+    template: templates/submodel-registry/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the Submodel Repository
+    template: templates/submodel-repository/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the Concept Description Repository
+    template: templates/cd-repository/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the Company Lookup Service
+    template: templates/company-lookup/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost
+
+  - it: injects the reader into the Digital Twin Registry
+    template: templates/digital-twin-registry/deployment.yaml
+    values:
+      - fixtures/database_reader_all_services.yaml
+    asserts:
+      - contains: *managedReaderHost

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -309,3 +309,38 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "abac.policyScope"
+
+  - it: fails when a reader pool limit is negative
+    values:
+      - fixtures/invalid_database_reader_pool.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.reader.maxOpenConnections"
+
+  - it: fails when a managed reader has no standby
+    values:
+      - fixtures/invalid_database_reader_single_instance.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.instances"
+
+  - it: fails when a read-only Pooler is enabled without the reader
+    values:
+      - fixtures/invalid_database_reader_pooler_disabled.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.reader.pooler.enabled"
+
+  - it: fails when a read-only Pooler is enabled for an external database
+    values:
+      - fixtures/invalid_database_reader_pooler_external.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.reader.pooler.enabled"
+
+  - it: fails when read-only Pooler monitoring is enabled without the Pooler
+    values:
+      - fixtures/invalid_database_reader_monitoring_without_pooler.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "database.reader.pooler.enabled"

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -530,6 +530,46 @@
         "environment": { "type": "object" }
       }
     },
+    "readerDatabase": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "host": { "type": "string" },
+        "port": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "string" }
+          ]
+        },
+        "dbname": { "type": "string" },
+        "user": { "type": "string" },
+        "password": { "type": "string" },
+        "sslmode": {
+          "type": "string",
+          "enum": ["", "disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+        },
+        "sslcert": { "type": "string" },
+        "sslkey": { "type": "string" },
+        "sslrootcert": { "type": "string" },
+        "connectTimeoutSeconds": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]*$" }
+          ]
+        },
+        "applicationName": { "type": "string" },
+        "fallbackApplicationName": { "type": "string" },
+        "searchPath": { "type": "string" },
+        "options": { "type": "string" },
+        "timezone": { "type": "string" },
+        "maxOpenConnections": { "type": "integer", "minimum": 0 },
+        "maxIdleConnections": { "type": "integer", "minimum": 0 },
+        "connMaxLifetimeMinutes": { "type": "integer", "minimum": 0 },
+        "connMaxIdleTimeMinutes": { "type": "integer", "minimum": 0 }
+      }
+    },
     "serviceDatabase": {
       "type": "object",
       "properties": {
@@ -563,6 +603,9 @@
         "searchPath": { "type": "string" },
         "options": { "type": "string" },
         "timezone": { "type": "string" },
+        "reader": {
+          "$ref": "#/definitions/readerDatabase"
+        },
         "external": {
           "type": "object",
           "properties": {
@@ -634,6 +677,9 @@
             }
           },
           "required": ["external"]
+        },
+        {
+          "required": ["reader"]
         }
       ]
     }
@@ -1208,7 +1254,7 @@
     "digitalTwinRegistry": { "$ref": "#/definitions/serviceRuntimeOverrides" },
     "database": {
       "type": "object",
-      "required": ["clusterName", "type", "instances", "storage"],
+      "required": ["clusterName", "type", "instances", "storage", "reader"],
       "properties": {
         "clusterName": {
           "type": "string",
@@ -1248,6 +1294,123 @@
             "options": { "type": "string" },
             "timezone": { "type": "string" }
           }
+        },
+        "reader": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/readerDatabase"
+            },
+            {
+              "type": "object",
+              "required": [
+                "existingSecret",
+                "host",
+                "port",
+                "dbname",
+                "user",
+                "password",
+                "sslmode",
+                "sslcert",
+                "sslkey",
+                "sslrootcert",
+                "connectTimeoutSeconds",
+                "applicationName",
+                "fallbackApplicationName",
+                "searchPath",
+                "options",
+                "timezone",
+                "maxOpenConnections",
+                "maxIdleConnections",
+                "connMaxLifetimeMinutes",
+                "connMaxIdleTimeMinutes",
+                "pooler"
+              ],
+              "properties": {
+                "pooler": {
+                  "$ref": "#/properties/database/properties/pooler"
+                }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "enabled": {
+                        "const": false
+                      }
+                    },
+                    "required": ["enabled"]
+                  },
+                  "then": {
+                    "properties": {
+                      "pooler": {
+                        "properties": {
+                          "enabled": {
+                            "const": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "pooler": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        },
+                        "required": ["enabled"]
+                      }
+                    },
+                    "required": ["pooler"]
+                  },
+                  "then": {
+                    "properties": {
+                      "existingSecret": {
+                        "const": ""
+                      },
+                      "host": {
+                        "const": ""
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "pooler": {
+                        "properties": {
+                          "monitoring": {
+                            "properties": {
+                              "enabled": {
+                                "const": true
+                              }
+                            },
+                            "required": ["enabled"]
+                          }
+                        },
+                        "required": ["monitoring"]
+                      }
+                    },
+                    "required": ["pooler"]
+                  },
+                  "then": {
+                    "properties": {
+                      "pooler": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         },
         "instances": {
           "type": "integer",
@@ -1681,6 +1844,56 @@
                   "size": {
                     "type": "string",
                     "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["postgres", "managed", "cnpg"]
+              },
+              "reader": {
+                "properties": {
+                  "enabled": { "const": true },
+                  "existingSecret": { "const": "" },
+                  "host": { "const": "" }
+                },
+                "required": ["enabled", "existingSecret", "host"]
+              }
+            },
+            "required": ["type", "reader"]
+          },
+          "then": {
+            "properties": {
+              "instances": {
+                "minimum": 2
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "external"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "reader": {
+                "properties": {
+                  "pooler": {
+                    "properties": {
+                      "enabled": {
+                        "const": false
+                      }
+                    }
                   }
                 }
               }

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1587,6 +1587,9 @@ database:
   # aasRegistry:
   #   database:
   #     existingSecret: basyx-aas-registry-postgres
+  #     reader:
+  #       enabled: true
+  #       host: postgres-reader.example.internal
   #
   # Or inline for test deployments:
   #
@@ -1600,6 +1603,67 @@ database:
   #     password: change-me
   #     sslmode: require
   #     searchPath: registry_schema
+  # Optional reader connection for BaSyx Go HTTP services. When disabled, the
+  # services reuse their writer pool and no POSTGRES_READER_* variables render.
+  # For managed CloudNativePG, enabling this targets <clusterName>-ro, or the
+  # read-only Pooler below when reader.pooler.enabled is also true.
+  reader:
+    enabled: false
+    # Existing reader Secret. It must contain host, port, dbname, user and
+    # password. Optional connection keys use the same names as database.external.
+    existingSecret: ""
+    # Inline connection values are stored in a generated Secret. Omitted values
+    # reuse the effective writer Secret, so setting only host avoids duplication.
+    host: ""
+    port: ""
+    dbname: ""
+    user: ""
+    password: ""
+    sslmode: ""
+    sslcert: ""
+    sslkey: ""
+    sslrootcert: ""
+    connectTimeoutSeconds: 0
+    applicationName: ""
+    fallbackApplicationName: ""
+    searchPath: ""
+    options: ""
+    timezone: ""
+    # Independent per-pod reader pool limits.
+    maxOpenConnections: 50
+    maxIdleConnections: 25
+    connMaxLifetimeMinutes: 5
+    connMaxIdleTimeMinutes: 0
+    # Optional CloudNativePG read-only Pooler. This requires a managed database,
+    # reader.enabled=true and at least two database instances.
+    pooler:
+      enabled: false
+      instances: 2
+      poolMode: transaction
+      maxClientConn: 1000
+      defaultPoolSize: 25
+      preparedStatements:
+        enabled: true
+        maxPreparedStatements: 100
+      # Additional CloudNativePG-supported PgBouncer parameters. Values must be
+      # strings. The three settings above take precedence over duplicate keys.
+      parameters: {}
+      resources: {}
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
+      topologySpreadConstraints: []
+      # Optional Prometheus Operator PodMonitor for the read-only Pooler.
+      monitoring:
+        enabled: false
+        labels: {}
+        annotations: {}
+        interval: 30s
+        scrapeTimeout: 10s
+        # Empty selects pods in the PodMonitor's namespace.
+        namespaceSelector: {}
+        relabelings: []
+        metricRelabelings: []
   # name for the cnpg cluster resource
   # clusterName: "basyx-database"
   # name of database

--- a/values/values.read-replica.example.yaml
+++ b/values/values.read-replica.example.yaml
@@ -1,0 +1,27 @@
+# Example overlay for routing eligible BaSyx Go reads to CloudNativePG standbys.
+#
+# Apply this together with a deployment values file. The managed database must
+# have at least two instances. Both Poolers and their PodMonitors are optional.
+
+database:
+  instances: 3
+
+  # Writer traffic can use the existing read-write Pooler independently.
+  pooler:
+    enabled: true
+    instances: 2
+
+  reader:
+    enabled: true
+    maxOpenConnections: 50
+    maxIdleConnections: 25
+    connMaxLifetimeMinutes: 5
+    connMaxIdleTimeMinutes: 0
+    pooler:
+      enabled: true
+      instances: 2
+      monitoring:
+        enabled: false
+        # Add labels required by your Prometheus podMonitorSelector:
+        # labels:
+        #   release: kube-prometheus-stack


### PR DESCRIPTION
## Summary

- add optional PostgreSQL reader configuration for all BaSyx Go HTTP services deployed by the chart
- route managed reader traffic to the CloudNativePG read-only Service or an optional `ro` Pooler
- support external reader Secrets and inline endpoints without duplicating writer credentials
- add independent reader pool limits, service-local overrides, schema validation and an example overlay
- add optional PodMonitor support for the read-only Pooler
- update the chart to `3.9.0` and BaSyx Go `1.0.7`
- skip the chart release job in forks

Reader routing is disabled by default. Existing deployments render no reader variables, read-only Pooler or read-only Pooler monitor. The Configuration Service and Keycloak remain writer-only.

Service-local writer overrides do not inherit the global reader unless they also configure a local reader. This prevents a service from reading from a different database by accident. A reader-only local override can still use the global writer.

## Dependencies

Reader connection support landed in [eclipse-basyx/basyx-go-components#540](https://github.com/eclipse-basyx/basyx-go-components/pull/540). This PR now depends on [eclipse-basyx/basyx-go-components#547](https://github.com/eclipse-basyx/basyx-go-components/pull/547), which keeps compound responses on one reader snapshot. It should not be merged until #547 is merged and the BaSyx Go `1.0.7` images are published.

Prometheus Operator and its CRDs are required only when read-only Pooler monitoring is enabled.

## Validation

- 15 Helm unit test suites, 194 tests
- `helm lint` with the default values and every documented values file
- default render checked for the absence of reader configuration and read-only resources
- read-replica example render and chart package build
- JSON schema and workflow YAML parsing
- upstream and fork branches of the release guard

Closes #87
