### PR TITLE
Add optional HorizontalPodAutoscaler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,13 @@ sum(BaSyx maximum replicas × POSTGRES_MAXOPENCONNECTIONS)
 < Pooler instances × maxClientConn
 ```
 
+This is an absolute aggregate ceiling, not a production target. Client
+connections are persistent and can be distributed unevenly across Pooler pods.
+For deployments that must tolerate one Pooler restart or failure, budget
+against `(Pooler instances - 1) × maxClientConn` and leave additional headroom
+for distribution skew. A single Pooler instance has no client-capacity
+redundancy.
+
 A Pooler controls connection concurrency; it does not add write capacity to the
 single PostgreSQL primary. If latency rises while PgBouncer clients wait for
 server connections, first inspect query time, lock contention, storage latency
@@ -1271,15 +1278,20 @@ available Kubernetes CPU. For a service that connects directly to PostgreSQL,
 keep:
 
 ```text
-maxReplicas × POSTGRES_MAXOPENCONNECTIONS
+(maxReplicas + rollout surge pods) × POSTGRES_MAXOPENCONNECTIONS
 <= that service's writer connection budget
 ```
 
+The shared Deployments use Kubernetes' default rolling-update strategy, which
+can create `ceil(maxReplicas × 25%)` surge pods. Include that overlap unless a
+post-renderer or another deployment policy sets a different `maxSurge`. This is
+the service-specific part of the complete PostgreSQL budget described above.
 Calculate the same limit independently for `POSTGRES_READER_MAXOPENCONNECTIONS`
 when reader routing is enabled. When PgBouncer is used, the HPA maximum must
-also fit its client limit and the Pooler server pools must stay within the
-PostgreSQL backend budget. PgBouncer queues connections but does not add write
-capacity to the primary.
+also fit the surviving Pooler client capacity with headroom for connection
+distribution, and the Pooler server pools must stay within the PostgreSQL
+backend budget. PgBouncer queues connections but does not add write capacity to
+the primary.
 
 Do not use HPA to react to PostgreSQL latency or an exhausted connection pool:
 adding application pods during a database incident can increase pressure.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ values/values.catena-x.example.yaml
 values/values.example.yaml
 values/values.minimal.yaml
 values/values.observability.example.yaml
+values/values.autoscaling.example.yaml
 values/values.secured.example.yaml
 ```
 
@@ -133,6 +134,9 @@ cp values/values.catena-x.example.yaml values/values.my-catena-x-environment.yam
 
 # Optional logging and tracing overlay for an existing Collector.
 cp values/values.observability.example.yaml values/values.my-observability.yaml
+
+# Optional HPA overlay for a BaSyx Go backend.
+cp values/values.autoscaling.example.yaml values/values.my-autoscaling.yaml
 ```
 
 The unsecured example enables the core BaSyx Go services and the Web UI:
@@ -215,6 +219,7 @@ helm lint charts/basyx -f values/values.minimal.yaml
 helm lint charts/basyx -f values/values.secured.example.yaml
 helm lint charts/basyx -f values/values.catena-x.example.yaml
 helm lint charts/basyx -f values/values.minimal.yaml -f values/values.observability.example.yaml
+helm lint charts/basyx -f values/values.example.yaml -f values/values.autoscaling.example.yaml
 
 helm template basyx charts/basyx \
   -n basyx-custom \
@@ -712,10 +717,13 @@ environment:
     POSTGRES_CONNMAXIDLETIMEMINUTES: 0
 ```
 
-Budget connections before increasing a service's `replicaCount`. For all pods that connect to the same PostgreSQL primary, keep:
+Budget connections before increasing a service's `replicaCount` or
+`autoscaling.maxReplicas`. Use `replicaCount` as the maximum when autoscaling is
+disabled and `autoscaling.maxReplicas` when it is enabled. For all pods that
+connect to the same PostgreSQL primary, keep:
 
 ```text
-sum(BaSyx replicaCount × POSTGRES_MAXOPENCONNECTIONS)
+sum(BaSyx maximum replicas × POSTGRES_MAXOPENCONNECTIONS)
 + Keycloak and other application pools
 + temporary rolling-update pods
 + migration jobs
@@ -796,7 +804,7 @@ PgBouncer queues work, but they must remain below the aggregate client capacity
 and within acceptable queueing latency:
 
 ```text
-sum(BaSyx replicas × POSTGRES_MAXOPENCONNECTIONS)
+sum(BaSyx maximum replicas × POSTGRES_MAXOPENCONNECTIONS)
 < Pooler instances × maxClientConn
 ```
 
@@ -1107,7 +1115,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    tag: "1.0.2"
+    tag: "1.0.7"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -1129,7 +1137,7 @@ Supported service blocks:
 - `companyLookup`
 - `digitalTwinRegistry`
 
-Most service blocks support `enabled`, `replicaCount`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `server`, `history`, `eventing`, `general` and `abac` overrides.
+Most service blocks support `enabled`, `replicaCount`, `autoscaling`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `server`, `history`, `eventing`, `general` and `abac` overrides.
 
 `aasEnvironment` uses the `eclipsebasyx/aasenvironment-go` image and defaults to service port `8082`. It can be deployed as a single BaSyx Go API endpoint backed by the chart's PostgreSQL database and Configuration Service. It enables AAS Registry, Submodel Registry and Discovery integration by default:
 
@@ -1206,6 +1214,78 @@ aasWebGui:
           type: None
           config: null
 ```
+
+#### Horizontal Pod Autoscaling
+
+Every BaSyx Go backend listed above can use an `autoscaling/v2`
+`HorizontalPodAutoscaler`. Autoscaling is disabled by default. When it is
+enabled, the chart omits `spec.replicas` from the Deployment so that Helm does
+not reset the replica count managed by the HPA.
+
+The HPA uses the Kubernetes resource metrics API. Install and verify a metrics
+pipeline such as Metrics Server before enabling it:
+
+```bash
+kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes
+kubectl top pods
+```
+
+CPU utilization requires a CPU request. Enabling a service HPA without
+`resources.requests.cpu` fails chart validation. A memory request is also
+required when `targetMemoryUtilizationPercentage` is configured.
+
+```yaml
+digitalTwinRegistry:
+  enabled: true
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 300
+```
+
+`behavior.scaleUp` and `behavior.scaleDown` accept Kubernetes HPA
+`stabilizationWindowSeconds`, `selectPolicy`, and `policies`. Leave `behavior`
+empty to use Kubernetes defaults. The static `replicaCount` remains the
+Deployment replica count only while autoscaling is disabled.
+
+Set `maxReplicas` from a measured service and database budget, not only from
+available Kubernetes CPU. For a service that connects directly to PostgreSQL,
+keep:
+
+```text
+maxReplicas × POSTGRES_MAXOPENCONNECTIONS
+<= that service's writer connection budget
+```
+
+Calculate the same limit independently for `POSTGRES_READER_MAXOPENCONNECTIONS`
+when reader routing is enabled. When PgBouncer is used, the HPA maximum must
+also fit its client limit and the Pooler server pools must stay within the
+PostgreSQL backend budget. PgBouncer queues connections but does not add write
+capacity to the primary.
+
+Do not use HPA to react to PostgreSQL latency or an exhausted connection pool:
+adding application pods during a database incident can increase pressure.
+Load-test scale-up, scale-down, rolling updates, standby loss, and the maximum
+replica count before production rollout. Start from
+[`values/values.autoscaling.example.yaml`](values/values.autoscaling.example.yaml).
 
 ### BaSyx Runtime Configuration
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.9.0
+version: 3.10.0
 appVersion: "1.0.7"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -307,11 +307,61 @@ Render service-local BaSyx runtime overrides as explicit container env values.
 {{- end }}
 
 {{/*
+Render an optional HorizontalPodAutoscaler for a BaSyx Go backend service.
+*/}}
+{{- define "basyx.service.hpa" -}}
+{{- $root := .root -}}
+{{- $values := index $root.Values .component -}}
+{{- $autoscaling := $values.autoscaling -}}
+{{- if gt (int $autoscaling.minReplicas) (int $autoscaling.maxReplicas) -}}
+{{- fail (printf "%s.autoscaling.minReplicas must not exceed %s.autoscaling.maxReplicas" .component .component) -}}
+{{- end -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include .fullnameHelper $root }}
+  {{- if $root.Values.argocd.enabled }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $root.Values.argocd.runtimeSyncWave | quote }}
+  {{- end }}
+  labels:
+    {{- include .labelsHelper $root | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include .fullnameHelper $root }}
+  minReplicas: {{ $autoscaling.minReplicas }}
+  maxReplicas: {{ $autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $autoscaling.targetCPUUtilizationPercentage }}
+    {{- with $autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- with $autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{/*
 Shared deployment template for the BaSyx Go backend services with common database/ABAC wiring.
+It also renders the service HPA when autoscaling is enabled.
 */}}
 {{- define "basyx.service.deployment" -}}
 {{- $root := .root -}}
 {{- $values := index $root.Values .component -}}
+{{- $autoscaling := $values.autoscaling | default dict -}}
 {{- $abac := dict "root" $root "component" .component "nameSuffix" .nameSuffix -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -324,7 +374,9 @@ metadata:
   labels:
     {{- include .labelsHelper $root | nindent 4 }}
 spec:
+  {{- if not $autoscaling.enabled }}
   replicas: {{ $values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include .selectorLabelsHelper $root | nindent 6 }}
@@ -431,6 +483,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- if $autoscaling.enabled }}
+---
+{{ include "basyx.service.hpa" . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/basyx/tests/README.md
+++ b/charts/basyx/tests/README.md
@@ -28,5 +28,6 @@ The suites cover stable chart contracts such as:
 - schema validation for required values and basic formats
 - managed PostgreSQL storage, WAL, resources, scheduling and parameters
 - optional CloudNativePG read-write and read-only Pooler rendering, reader routing, and monitoring
+- optional CPU and memory HorizontalPodAutoscalers for every shared BaSyx Go backend deployment
 - shared per-pod PostgreSQL pool defaults and Configuration Service propagation
 - keycloak init resources and a runtime `helm test` realm check

--- a/charts/basyx/tests/autoscaling_test.yaml
+++ b/charts/basyx/tests/autoscaling_test.yaml
@@ -1,0 +1,229 @@
+suite: backend autoscaling
+release:
+  name: basyx
+templates:
+  - templates/aas-discovery/deployment.yaml
+  - templates/aas-environment/deployment.yaml
+  - templates/aas-registry/deployment.yaml
+  - templates/aas-repository/deployment.yaml
+  - templates/cd-repository/deployment.yaml
+  - templates/company-lookup/deployment.yaml
+  - templates/digital-twin-registry/deployment.yaml
+  - templates/dpp-api/deployment.yaml
+  - templates/submodel-registry/deployment.yaml
+  - templates/submodel-repository/deployment.yaml
+tests:
+  - it: keeps the static replica count when autoscaling is disabled
+    template: templates/aas-repository/deployment.yaml
+    set:
+      aasRepository.enabled: true
+      aasRepository.replicaCount: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: omits the static replica count when autoscaling is enabled
+    template: templates/aas-repository/deployment.yaml
+    documentIndex: 0
+    set:
+      aasRepository.enabled: true
+      aasRepository.replicaCount: 9
+      aasRepository.autoscaling.enabled: true
+      aasRepository.resources.requests.cpu: 250m
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: renders CPU and memory targets with scaling behavior
+    template: templates/aas-repository/deployment.yaml
+    documentIndex: 1
+    values:
+      - fixtures/autoscaling_full.yaml
+    asserts:
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+      - equal:
+          path: kind
+          value: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.name
+          value: basyx-aas-repository
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "20"
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: basyx-aas-repository
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 6
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 65
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+      - equal:
+          path: spec.behavior.scaleUp
+          value:
+            stabilizationWindowSeconds: 30
+            selectPolicy: Max
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 60
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: omits the optional memory metric and empty behavior
+    template: templates/aas-repository/deployment.yaml
+    documentIndex: 1
+    set:
+      aasRepository.enabled: true
+      aasRepository.autoscaling.enabled: true
+      aasRepository.resources.requests.cpu: 250m
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - notExists:
+          path: spec.behavior
+
+  - it: fails when minimum replicas exceed maximum replicas
+    template: templates/aas-repository/deployment.yaml
+    values:
+      - fixtures/invalid_autoscaling_replica_range.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.autoscaling.minReplicas must not exceed aasRepository.autoscaling.maxReplicas"
+
+  - it: enables autoscaling for AAS Discovery
+    template: templates/aas-discovery/deployment.yaml
+    documentIndex: 1
+    set:
+      aasDiscovery.enabled: true
+      aasDiscovery.autoscaling.enabled: true
+      aasDiscovery.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-aas-discovery
+
+  - it: enables autoscaling for AAS Environment
+    template: templates/aas-environment/deployment.yaml
+    documentIndex: 1
+    set:
+      aasEnvironment.enabled: true
+      aasEnvironment.autoscaling.enabled: true
+      aasEnvironment.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-aas-environment
+
+  - it: enables autoscaling for AAS Registry
+    template: templates/aas-registry/deployment.yaml
+    documentIndex: 1
+    set:
+      aasRegistry.enabled: true
+      aasRegistry.autoscaling.enabled: true
+      aasRegistry.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-aas-registry
+
+  - it: enables autoscaling for Concept Description Repository
+    template: templates/cd-repository/deployment.yaml
+    documentIndex: 1
+    set:
+      cdRepository.enabled: true
+      cdRepository.autoscaling.enabled: true
+      cdRepository.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-cd-repository
+
+  - it: enables autoscaling for Company Lookup
+    template: templates/company-lookup/deployment.yaml
+    documentIndex: 1
+    set:
+      companyLookup.enabled: true
+      companyLookup.autoscaling.enabled: true
+      companyLookup.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-company-lookup
+
+  - it: enables autoscaling for Digital Twin Registry
+    template: templates/digital-twin-registry/deployment.yaml
+    documentIndex: 1
+    set:
+      digitalTwinRegistry.enabled: true
+      digitalTwinRegistry.autoscaling.enabled: true
+      digitalTwinRegistry.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-digital-twin-registry
+
+  - it: enables autoscaling for DPP API
+    template: templates/dpp-api/deployment.yaml
+    documentIndex: 1
+    set:
+      dppApi.enabled: true
+      dppApi.autoscaling.enabled: true
+      dppApi.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-dpp-api
+
+  - it: enables autoscaling for Submodel Registry
+    template: templates/submodel-registry/deployment.yaml
+    documentIndex: 1
+    set:
+      submodelRegistry.enabled: true
+      submodelRegistry.autoscaling.enabled: true
+      submodelRegistry.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-submodel-registry
+
+  - it: enables autoscaling for Submodel Repository
+    template: templates/submodel-repository/deployment.yaml
+    documentIndex: 1
+    set:
+      submodelRepository.enabled: true
+      submodelRepository.autoscaling.enabled: true
+      submodelRepository.resources.requests.cpu: 100m
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: basyx-submodel-repository

--- a/charts/basyx/tests/fixtures/autoscaling_full.yaml
+++ b/charts/basyx/tests/fixtures/autoscaling_full.yaml
@@ -1,0 +1,25 @@
+argocd:
+  enabled: true
+
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 65
+    targetMemoryUtilizationPercentage: 75
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 300
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request.yaml
@@ -1,0 +1,4 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request_zero.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request_zero.yaml
@@ -1,0 +1,7 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+  resources:
+    requests:
+      cpu: 0

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request_zero_quantity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_request_zero_quantity.yaml
@@ -1,0 +1,7 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+  resources:
+    requests:
+      cpu: "0m"

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_target.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_cpu_target.yaml
@@ -1,0 +1,8 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    targetCPUUtilizationPercentage: 0
+  resources:
+    requests:
+      cpu: 250m

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request.yaml
@@ -1,0 +1,8 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: 250m

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request_zero.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request_zero.yaml
@@ -1,0 +1,9 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: 250m
+      memory: 0

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request_zero_quantity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_memory_request_zero_quantity.yaml
@@ -1,0 +1,9 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: 250m
+      memory: "0Mi"

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_policy.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_policy.yaml
@@ -1,0 +1,13 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    behavior:
+      scaleUp:
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 0
+  resources:
+    requests:
+      cpu: 250m

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_replica_range.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_replica_range.yaml
@@ -1,0 +1,9 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 5
+    maxReplicas: 2
+  resources:
+    requests:
+      cpu: 250m

--- a/charts/basyx/tests/fixtures/invalid_autoscaling_resource_quantity.yaml
+++ b/charts/basyx/tests/fixtures/invalid_autoscaling_resource_quantity.yaml
@@ -1,0 +1,7 @@
+aasRepository:
+  enabled: true
+  autoscaling:
+    enabled: true
+  resources:
+    requests:
+      cpu: not-a-quantity

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -107,6 +107,27 @@ tests:
       - failedTemplate:
           errorPattern: "aasRepository.resources"
 
+  - it: fails when autoscaling has a numeric zero CPU request
+    values:
+      - fixtures/invalid_autoscaling_cpu_request_zero.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources.requests.cpu"
+
+  - it: fails when autoscaling has a zero CPU quantity
+    values:
+      - fixtures/invalid_autoscaling_cpu_request_zero_quantity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources.requests.cpu"
+
+  - it: fails when autoscaling has an invalid CPU quantity
+    values:
+      - fixtures/invalid_autoscaling_resource_quantity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources.requests.cpu"
+
   - it: fails when the autoscaling CPU target is invalid
     values:
       - fixtures/invalid_autoscaling_cpu_target.yaml
@@ -120,6 +141,20 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "aasRepository.resources"
+
+  - it: fails when memory autoscaling has a numeric zero memory request
+    values:
+      - fixtures/invalid_autoscaling_memory_request_zero.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources.requests.memory"
+
+  - it: fails when memory autoscaling has a zero memory quantity
+    values:
+      - fixtures/invalid_autoscaling_memory_request_zero_quantity.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources.requests.memory"
 
   - it: fails when an autoscaling policy period is invalid
     values:

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -100,6 +100,34 @@ tests:
       - failedTemplate:
           errorPattern: "aasRepository.server.shutdownTimeoutSeconds"
 
+  - it: fails when autoscaling has no CPU request
+    values:
+      - fixtures/invalid_autoscaling_cpu_request.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources"
+
+  - it: fails when the autoscaling CPU target is invalid
+    values:
+      - fixtures/invalid_autoscaling_cpu_target.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.autoscaling.targetCPUUtilizationPercentage"
+
+  - it: fails when memory autoscaling has no memory request
+    values:
+      - fixtures/invalid_autoscaling_memory_request.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.resources"
+
+  - it: fails when an autoscaling policy period is invalid
+    values:
+      - fixtures/invalid_autoscaling_policy.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "aasRepository.autoscaling.behavior.scaleUp.policies.0.periodSeconds"
+
   - it: fails when the logging format is unsupported
     values:
       - fixtures/invalid_logging_format.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -502,6 +502,112 @@
         }
       }
     },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string", "minLength": 1 },
+          { "type": "number", "minimum": 0 }
+        ]
+      }
+    },
+    "resourceRequirements": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "$ref": "#/definitions/resourceList"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceList"
+        }
+      }
+    },
+    "hpaScalingPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value", "periodSeconds"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Pods", "Percent"]
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1800
+        }
+      }
+    },
+    "hpaScalingRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stabilizationWindowSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3600
+        },
+        "selectPolicy": {
+          "type": "string",
+          "enum": ["Max", "Min", "Disabled"]
+        },
+        "policies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/hpaScalingPolicy"
+          }
+        }
+      }
+    },
+    "serviceAutoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "minReplicas",
+        "maxReplicas",
+        "targetCPUUtilizationPercentage",
+        "behavior"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "behavior": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scaleUp": {
+              "$ref": "#/definitions/hpaScalingRules"
+            },
+            "scaleDown": {
+              "$ref": "#/definitions/hpaScalingRules"
+            }
+          }
+        }
+      }
+    },
     "serviceRuntimeOverrides": {
       "type": "object",
       "properties": {
@@ -527,8 +633,65 @@
             }
           }
         },
-        "environment": { "type": "object" }
-      }
+        "environment": { "type": "object" },
+        "resources": { "$ref": "#/definitions/resourceRequirements" },
+        "autoscaling": { "$ref": "#/definitions/serviceAutoscaling" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["autoscaling"],
+            "properties": {
+              "autoscaling": {
+                "required": ["enabled"],
+                "properties": {
+                  "enabled": { "const": true }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": ["resources"],
+            "properties": {
+              "resources": {
+                "required": ["requests"],
+                "properties": {
+                  "requests": {
+                    "required": ["cpu"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["autoscaling"],
+            "properties": {
+              "autoscaling": {
+                "required": ["enabled", "targetMemoryUtilizationPercentage"],
+                "properties": {
+                  "enabled": { "const": true },
+                  "targetMemoryUtilizationPercentage": { "type": "integer" }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": ["resources"],
+            "properties": {
+              "resources": {
+                "required": ["requests"],
+                "properties": {
+                  "requests": {
+                    "required": ["memory"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "readerDatabase": {
       "type": "object",

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -522,6 +522,27 @@
         }
       }
     },
+    "positiveResourceQuantity": {
+      "oneOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "string",
+          "allOf": [
+            {
+              "pattern": "^\\+?(?:[0-9]+(?:\\.[0-9]*)?|\\.[0-9]+)(?:[numkMGTPE]|[KMGTPE]i|[eE][+-]?[0-9]+)?$"
+            },
+            {
+              "not": {
+                "pattern": "^\\+?(?:0+(?:\\.0*)?|\\.0+)(?:[numkMGTPE]|[KMGTPE]i|[eE][+-]?[0-9]+)?$"
+              }
+            }
+          ]
+        }
+      ]
+    },
     "hpaScalingPolicy": {
       "type": "object",
       "additionalProperties": false,
@@ -657,7 +678,12 @@
                 "required": ["requests"],
                 "properties": {
                   "requests": {
-                    "required": ["cpu"]
+                    "required": ["cpu"],
+                    "properties": {
+                      "cpu": {
+                        "$ref": "#/definitions/positiveResourceQuantity"
+                      }
+                    }
                   }
                 }
               }
@@ -684,7 +710,12 @@
                 "required": ["requests"],
                 "properties": {
                   "requests": {
-                    "required": ["memory"]
+                    "required": ["memory"],
+                    "properties": {
+                      "memory": {
+                        "$ref": "#/definitions/positiveResourceQuantity"
+                      }
+                    }
                   }
                 }
               }

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -492,6 +492,13 @@ keycloak:
 submodelRepository:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/submodelrepository-go
     pullPolicy: IfNotPresent
@@ -582,6 +589,13 @@ submodelRepository:
 submodelRegistry:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/submodelregistry-go
     pullPolicy: IfNotPresent
@@ -669,6 +683,13 @@ submodelRegistry:
 aasRegistry:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/aasregistry-go
     pullPolicy: IfNotPresent
@@ -767,6 +788,13 @@ aasRegistry:
 digitalTwinRegistry:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/digitaltwinregistry-go
     pullPolicy: IfNotPresent
@@ -864,6 +892,13 @@ digitalTwinRegistry:
 aasRepository:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/aasrepository-go
     pullPolicy: IfNotPresent
@@ -959,6 +994,13 @@ aasRepository:
 aasEnvironment:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/aasenvironment-go
     pullPolicy: IfNotPresent
@@ -1058,6 +1100,13 @@ aasEnvironment:
 dppApi:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/dppapi-go
     pullPolicy: IfNotPresent
@@ -1151,6 +1200,13 @@ dppApi:
 cdRepository:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/conceptdescriptionrepository-go
     pullPolicy: IfNotPresent
@@ -1242,6 +1298,13 @@ cdRepository:
 companyLookup:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/companylookup-go
     pullPolicy: IfNotPresent
@@ -1325,6 +1388,13 @@ companyLookup:
 aasDiscovery:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: eclipsebasyx/aasdiscovery-go
     pullPolicy: IfNotPresent

--- a/values/values.autoscaling.example.yaml
+++ b/values/values.autoscaling.example.yaml
@@ -1,0 +1,39 @@
+# Example overlay for HorizontalPodAutoscaler support on a BaSyx Go backend.
+#
+# Apply this together with a deployment values file. The cluster must expose
+# resource metrics, for example through Metrics Server. Treat these values as a
+# starting point and replace them with limits measured for the target workload
+# and PostgreSQL connection budget.
+
+digitalTwinRegistry:
+  enabled: true
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 25
+            periodSeconds: 60


### PR DESCRIPTION
## Summary

- add optional `autoscaling/v2` HorizontalPodAutoscalers to every BaSyx Go backend that uses the shared deployment template
- support CPU utilization, optional memory utilization, minimum and maximum replicas, and Kubernetes scale-up/scale-down behavior
- omit the static Deployment replica count while autoscaling is enabled
- require valid positive CPU requests for CPU utilization and valid positive memory requests when memory utilization is configured
- keep autoscaling disabled by default and leave Keycloak, the Web UI, and the Configuration Service unchanged
- add an autoscaling example and document metrics, resource, PostgreSQL, reader pool, rollout surge, and PgBouncer capacity requirements
- update the chart version to `3.10.0`

The HPA uses the Kubernetes resource metrics API. `maxReplicas` plus rolling-update overlap still has to fit the service's writer and reader connection budgets. PgBouncer can queue excess client work, but it does not add write capacity to the PostgreSQL primary. Production client budgets also need to fit surviving Pooler capacity with headroom for connection distribution.

## Validation

- 16 Helm unit test suites, 217 tests
- HPA rendering covered for all 10 shared BaSyx Go backend deployments
- schema validation for positive resource requests, utilization targets, scaling policies, and replica ranges
- `helm lint` with the defaults and every documented values file
- chart-testing lint and version-increment validation
- default render comparison against chart 3.9.0
- autoscaling example render and chart package build
- JSON and YAML parsing

Closes #88
