### PR TITLE
Release chart 3.10.1 for BaSyx Go 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1624,7 +1624,7 @@ Enable the Web UI with:
 aasWebGui:
   enabled: true
   image:
-    tag: v2-260707
+    tag: v2-260801
 ```
 
 The Web UI infrastructure is rendered from `aasWebGui.infrastructureConfig`. The defaults derive service URLs from `host` and `paths.*`.

--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    tag: "1.0.7"
+    tag: "1.0.8"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.10.0
-appVersion: "1.0.7"
+version: 3.10.1
+appVersion: "1.0.8"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -1488,7 +1488,7 @@ aasWebGui:
   image:
     repository: eclipsebasyx/aas-gui
     pullPolicy: Always
-    tag: 66ff34d
+    tag: v2-260801
   imagePullSecrets: []
   nameOverride: "aas-gui"
   fullnameOverride: "aas-gui"


### PR DESCRIPTION
## What changed

- update the chart version from 3.10.0 to 3.10.1
- use BaSyx Go 1.0.8 as the default application and image version
- use BaSyx UI v2-260801 as the default Web UI image
- update the service configuration and Web UI examples

This remains a patch release because it only updates default image versions and documentation. The rendered Kubernetes API remains unchanged.

## Dependencies

This PR depends on eclipse-basyx/basyx-go-components#554 and the BaSyx Go 1.0.8 images being published.

The BaSyx UI v2-260801 release is published. Its image publication workflow must complete successfully before this PR is merged.

## Validation

- linted the chart with the default, example, minimal, secured, Catena-X, observability and autoscaling values
- ran all 217 Helm unit tests
- rendered the example deployment and verified the 3.10.1 chart labels, 1.0.8 BaSyx Go images and v2-260801 BaSyx UI image
- packaged `basyx-3.10.1.tgz`
