### PR TITLE
Add topology spread settings for backend services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,7 +1144,32 @@ Supported service blocks:
 - `companyLookup`
 - `digitalTwinRegistry`
 
-Most service blocks support `enabled`, `replicaCount`, `autoscaling`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `server`, `history`, `eventing`, `general` and `abac` overrides.
+Most service blocks support `enabled`, `replicaCount`, `autoscaling`, `image.*`, `imagePullSecrets`, `service.*`, `ingress.*`, `resources`, `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`, `podAnnotations`, `podLabels`, `podSecurityContext`, `securityContext`, `volumes`, `volumeMounts` and optional service-local `server`, `history`, `eventing`, `general` and `abac` overrides.
+
+Use topology spread constraints to distribute replicas across nodes or zones. A
+dedicated pod label keeps the selector independent of the Helm release name:
+
+```yaml
+submodelRepository:
+  replicaCount: 3
+  podLabels:
+    basyx.eclipse.org/topology-group: submodel-repository
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          basyx.eclipse.org/topology-group: submodel-repository
+      matchLabelKeys:
+        - pod-template-hash
+```
+
+The selector must match the labels of the service's own pods. Use
+`DoNotSchedule` only after verifying that enough eligible topology domains and
+capacity are available, otherwise replicas can remain pending. `matchLabelKeys`
+requires Kubernetes 1.27 or later, and `minDomains` can require feature-gate
+support before Kubernetes 1.30.
 
 `aasEnvironment` uses the `eclipsebasyx/aasenvironment-go` image and defaults to service port `8082`. It can be deployed as a single BaSyx Go API endpoint backed by the chart's PostgreSQL database and Configuration Service. It enables AAS Registry, Submodel Registry and Discovery integration by default:
 

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.10.1
+version: 3.11.0
 appVersion: "1.0.8"
 home: https://github.com/eclipse-basyx/charts
 sources:

--- a/charts/basyx/templates/_helpers.tpl
+++ b/charts/basyx/templates/_helpers.tpl
@@ -479,6 +479,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/basyx/tests/backend_deployments_test.yaml
+++ b/charts/basyx/tests/backend_deployments_test.yaml
@@ -80,6 +80,25 @@ tests:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "20"
 
+  - it: renders topology spread constraints for shared backend deployments
+    template: templates/aas-repository/deployment.yaml
+    values:
+      - fixtures/backend_topology_spread.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0]
+          value:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: aas-repository
+                app.kubernetes.io/name: basyx
+            matchLabelKeys:
+              - pod-template-hash
+            maxSkew: 1
+            minDomains: 3
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+
   - it: renders Argo CD runtime sync wave for keycloak
     template: templates/keycloak/deployment.yaml
     set:

--- a/charts/basyx/tests/fixtures/backend_topology_spread.yaml
+++ b/charts/basyx/tests/fixtures/backend_topology_spread.yaml
@@ -1,0 +1,13 @@
+aasRepository:
+  enabled: true
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      minDomains: 3
+      matchLabelKeys:
+        - pod-template-hash
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: basyx
+          app.kubernetes.io/component: aas-repository

--- a/charts/basyx/tests/fixtures/invalid_backend_topology_spread.yaml
+++ b/charts/basyx/tests/fixtures/invalid_backend_topology_spread.yaml
@@ -1,0 +1,4 @@
+aasRepository:
+  topologySpreadConstraints:
+    - topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule

--- a/charts/basyx/tests/schema_validation_test.yaml
+++ b/charts/basyx/tests/schema_validation_test.yaml
@@ -100,6 +100,13 @@ tests:
       - failedTemplate:
           errorPattern: "aasRepository.server.shutdownTimeoutSeconds"
 
+  - it: fails when a backend topology spread constraint is incomplete
+    values:
+      - fixtures/invalid_backend_topology_spread.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "maxSkew is required"
+
   - it: fails when autoscaling has no CPU request
     values:
       - fixtures/invalid_autoscaling_cpu_request.yaml

--- a/charts/basyx/values.schema.json
+++ b/charts/basyx/values.schema.json
@@ -78,6 +78,72 @@
         }
       }
     },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+        "properties": {
+          "maxSkew": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "topologyKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "whenUnsatisfiable": {
+            "type": "string",
+            "enum": ["DoNotSchedule", "ScheduleAnyway"]
+          },
+          "labelSelector": {
+            "$ref": "#/definitions/labelSelector"
+          },
+          "minDomains": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "matchLabelKeys": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "nodeAffinityPolicy": {
+            "type": "string",
+            "enum": ["Honor", "Ignore"]
+          },
+          "nodeTaintsPolicy": {
+            "type": "string",
+            "enum": ["Honor", "Ignore"]
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "required": ["minDomains"]
+            },
+            "then": {
+              "properties": {
+                "whenUnsatisfiable": {
+                  "const": "DoNotSchedule"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": ["matchLabelKeys"]
+            },
+            "then": {
+              "required": ["labelSelector"]
+            }
+          }
+        ]
+      }
+    },
     "nodeSelectorRequirement": {
       "type": "object",
       "additionalProperties": false,
@@ -656,7 +722,8 @@
         },
         "environment": { "type": "object" },
         "resources": { "$ref": "#/definitions/resourceRequirements" },
-        "autoscaling": { "$ref": "#/definitions/serviceAutoscaling" }
+        "autoscaling": { "$ref": "#/definitions/serviceAutoscaling" },
+        "topologySpreadConstraints": { "$ref": "#/definitions/topologySpreadConstraints" }
       },
       "allOf": [
         {

--- a/charts/basyx/values.yaml
+++ b/charts/basyx/values.yaml
@@ -575,6 +575,7 @@ submodelRepository:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:
@@ -669,6 +670,7 @@ submodelRegistry:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:
@@ -771,6 +773,7 @@ aasRegistry:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # For HA deployments (replicaCount > 1), configure pod anti-affinity to spread
   # replicas across nodes. Adjust matchLabels to this service's app.kubernetes.io/name.
   # affinity:
@@ -876,6 +879,7 @@ digitalTwinRegistry:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # For HA deployments (replicaCount > 1), configure pod anti-affinity to spread
   # replicas across nodes. Adjust matchLabels to this service's app.kubernetes.io/name.
   # affinity:
@@ -980,6 +984,7 @@ aasRepository:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:
@@ -1084,6 +1089,7 @@ aasEnvironment:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # volumes:
   #   - name: aas-preconfiguration
   #     configMap:
@@ -1195,6 +1201,7 @@ dppApi:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   affinity: {}
 
 cdRepository:
@@ -1284,6 +1291,7 @@ cdRepository:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:
@@ -1373,6 +1381,7 @@ companyLookup:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:
@@ -1468,6 +1477,7 @@ aasDiscovery:
     failureThreshold: 3
   nodeSelector: {}
   tolerations: []
+  topologySpreadConstraints: []
   # affinity:
   #   podAntiAffinity:
   #     preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## What changed

- add `topologySpreadConstraints` to all BaSyx backend service values
- render the constraints through the shared deployment template
- validate the Kubernetes fields in the values schema
- document rollout-safe selectors and scheduling compatibility considerations
- bump the chart version to `3.11.0`

This allows multi-replica services to be distributed across failure domains without maintaining deployment patches outside the chart. The setting is opt-in and empty by default, so existing deployments keep their current scheduling behavior. `matchLabelKeys` is supported so Deployment revisions can be spread independently.

## Tested

- `helm lint charts/basyx`
- `helm unittest charts/basyx` (219 tests)
- rendered a multi-replica backend configuration with topology spread constraints