### PR TITLE
Release chart 3.11.1 for BaSyx Go 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,7 @@ aasRepository:
   replicaCount: 1
   image:
     repository: eclipsebasyx/aasrepository-go
-    tag: "1.0.8"
+    tag: "1.0.9"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/charts/basyx/Chart.yaml
+++ b/charts/basyx/Chart.yaml
@@ -5,8 +5,8 @@ description: >
   including AAS registries, repositories, discovery service, and optional
   Keycloak authentication with ABAC authorization.
 type: application
-version: 3.11.0
-appVersion: "1.0.8"
+version: 3.11.1
+appVersion: "1.0.9"
 home: https://github.com/eclipse-basyx/charts
 sources:
   - https://github.com/eclipse-basyx/charts


### PR DESCRIPTION
## What changed

- release chart version 3.11.1
- use BaSyx Go 1.0.9 as the default application and image version
- update the README image override example to 1.0.9

## Why

BaSyx Go 1.0.9 has been released and contains the PostgreSQL read query plan reuse improvements.

## Validation

- `helm lint charts/basyx`
- lint with the example, minimal, secured, Catena-X, observability and autoscaling values
- `helm unittest charts/basyx`
- rendered all BaSyx Go service images with tag `1.0.9`
- packaged the chart locally